### PR TITLE
Add predicate keyword to fmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,22 @@ Any field not in the list will not be returned by `functor` and passed through a
 It is also possible to implement `functor` by hand when greater flexibility is required. See [here](https://github.com/FluxML/Functors.jl/issues/3) for an example.
 
 For a discussion regarding the need for a `cache` in the implementation of `fmap`, see [here](https://github.com/FluxML/Functors.jl/issues/2).
+
+To control the depth of descent by `fmap`, the keyword `predicate` can be used:
+```julia
+julia> using CUDA
+
+julia> x = ['a', 'b', 'c'];
+
+julia> fmap(cu, x)
+3-element Array{Char,1}:
+ 'a': ASCII/Unicode U+0061 (category Ll: Letter, lowercase)
+ 'b': ASCII/Unicode U+0062 (category Ll: Letter, lowercase)
+ 'c': ASCII/Unicode U+0063 (category Ll: Letter, lowercase)
+
+julia> fmap(cu, x; predicate = CUDA.isbits)
+3-element CuArray{Char,1}:
+ 'a': ASCII/Unicode U+0061 (category Ll: Letter, lowercase)
+ 'b': ASCII/Unicode U+0062 (category Ll: Letter, lowercase)
+ 'c': ASCII/Unicode U+0063 (category Ll: Letter, lowercase)
+```

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ It is also possible to implement `functor` by hand when greater flexibility is r
 
 For a discussion regarding the need for a `cache` in the implementation of `fmap`, see [here](https://github.com/FluxML/Functors.jl/issues/2).
 
-To control the depth of descent by `fmap`, the keyword `predicate` can be used:
+Use `predicate` for more fine-grained control over whether `fmap` descends into a particular value:
 ```julia
 julia> using CUDA
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ It is also possible to implement `functor` by hand when greater flexibility is r
 
 For a discussion regarding the need for a `cache` in the implementation of `fmap`, see [here](https://github.com/FluxML/Functors.jl/issues/2).
 
-Use `predicate` for more fine-grained control over whether `fmap` descends into a particular value:
+Use `predicate` for more fine-grained control over whether `fmap` descends into a particular value (the default is `predicate = Functors.isleaf`):
 ```julia
 julia> using CUDA
 
@@ -84,7 +84,7 @@ julia> fmap(cu, x)
  'b': ASCII/Unicode U+0062 (category Ll: Letter, lowercase)
  'c': ASCII/Unicode U+0063 (category Ll: Letter, lowercase)
 
-julia> fmap(cu, x; predicate = CUDA.isbits)
+julia> fmap(cu, x; predicate = CUDA.isbitstype(eltype(x)))
 3-element CuArray{Char,1}:
  'a': ASCII/Unicode U+0061 (category Ll: Letter, lowercase)
  'b': ASCII/Unicode U+0062 (category Ll: Letter, lowercase)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ It is also possible to implement `functor` by hand when greater flexibility is r
 
 For a discussion regarding the need for a `cache` in the implementation of `fmap`, see [here](https://github.com/FluxML/Functors.jl/issues/2).
 
-Use `predicate` for more fine-grained control over whether `fmap` descends into a particular value (the default is `predicate = Functors.isleaf`):
+Use `exclude` for more fine-grained control over whether `fmap` descends into a particular value (the default is `exclude = Functors.isleaf`):
 ```julia
 julia> using CUDA
 
@@ -84,7 +84,7 @@ julia> fmap(cu, x)
  'b': ASCII/Unicode U+0062 (category Ll: Letter, lowercase)
  'c': ASCII/Unicode U+0063 (category Ll: Letter, lowercase)
 
-julia> fmap(cu, x; predicate = CUDA.isbitstype(eltype(x)))
+julia> fmap(cu, x; exclude = x -> CUDA.isbitstype(eltype(x)))
 3-element CuArray{Char,1}:
  'a': ASCII/Unicode U+0061 (category Ll: Letter, lowercase)
  'b': ASCII/Unicode U+0062 (category Ll: Letter, lowercase)

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -51,7 +51,7 @@ end
 
 # See https://github.com/FluxML/Functors.jl/issues/2 for a discussion regarding the need for
 # cache.
-function fmap(f, x; predicate = () -> false, cache = IdDict())
+function fmap(f, x; predicate = x -> false, cache = IdDict())
   haskey(cache, x) && return cache[x]
   cache[x] = (predicate(x) || isleaf(x)) ? f(x) : fmap1(x -> fmap(f, x, cache = cache), x)
 end

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -51,9 +51,12 @@ end
 
 # See https://github.com/FluxML/Functors.jl/issues/2 for a discussion regarding the need for
 # cache.
-function fmap(f, x; predicate = isleaf, cache = IdDict())
+function fmap(f, x; exclude = isleaf, cache = IdDict())
   haskey(cache, x) && return cache[x]
-  cache[x] = predicate(x) ? f(x) : fmap1(x -> fmap(f, x, cache = cache), x)
+  y = exclude(x) ? f(x) : fmap1(x -> fmap(f, x, cache = cache, exclude = exclude), x)
+  cache[x] = y
+
+  return y
 end
 
 """

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -51,9 +51,9 @@ end
 
 # See https://github.com/FluxML/Functors.jl/issues/2 for a discussion regarding the need for
 # cache.
-function fmap(f, x; predicate = x -> false, cache = IdDict())
+function fmap(f, x; predicate = isleaf, cache = IdDict())
   haskey(cache, x) && return cache[x]
-  cache[x] = (predicate(x) || isleaf(x)) ? f(x) : fmap1(x -> fmap(f, x, cache = cache), x)
+  cache[x] = predicate(x) ? f(x) : fmap1(x -> fmap(f, x, cache = cache), x)
 end
 
 """

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -51,9 +51,9 @@ end
 
 # See https://github.com/FluxML/Functors.jl/issues/2 for a discussion regarding the need for
 # cache.
-function fmap(f, x; cache = IdDict())
+function fmap(f, x; predicate = () -> false, cache = IdDict())
   haskey(cache, x) && return cache[x]
-  cache[x] = isleaf(x) ? f(x) : fmap1(x -> fmap(f, x, cache = cache), x)
+  cache[x] = (predicate(x) || isleaf(x)) ? f(x) : fmap1(x -> fmap(f, x, cache = cache), x)
 end
 
 """

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -32,7 +32,16 @@ end
   @test model′.x.y isa Vector{Float64}
 end
 
-@testset "Property list" begin  
+@testset "Predicate" begin
+  f(x::AbstractArray) = x
+  f(x::Char) = 'z'
+
+  x = ['a', 'b', 'c']
+  @test fmap(f, x)  == ['z', 'z', 'z']
+  @test fmap(f, x; predicate = x -> x isa AbstractArray) == x
+end
+
+@testset "Property list" begin
   model = Baz(1, 2, 3)
   model′ = fmap(x -> 2x, model)
   

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -32,13 +32,17 @@ end
   @test model′.x.y isa Vector{Float64}
 end
 
-@testset "Predicate" begin
+@testset "Exclude" begin
   f(x::AbstractArray) = x
   f(x::Char) = 'z'
 
   x = ['a', 'b', 'c']
   @test fmap(f, x)  == ['z', 'z', 'z']
-  @test fmap(f, x; predicate = x -> x isa AbstractArray) == x
+  @test fmap(f, x; exclude = x -> x isa AbstractArray) == x
+
+  x = (['a', 'b', 'c'], ['d', 'e', 'f'])
+  @test fmap(f, x)  == (['z', 'z', 'z'], ['z', 'z', 'z'])
+  @test fmap(f, x; exclude = x -> x isa AbstractArray) == x
 end
 
 @testset "Property list" begin


### PR DESCRIPTION
This adds a `predicate` keyword to control the descent of `fmap`. Now, `fmap(f, x; predicate = ...)` applies `f(x)` if `isleaf(x) || predicate(x)`, otherwise it uses `functor` to descend further into `x`. By default, `predicate` is has no effect on the previous behavior.

This addition lets us deal with issues like https://github.com/FluxML/Flux.jl/issues/1517 without needing to special case every possible leaf situation (which we might not want to do for certain types).