### PR TITLE
add fcollect

### DIFF
--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -2,7 +2,7 @@ module Functors
 
 using MacroTools
 
-export @functor, fmap
+export @functor, fmap, fcollect
 
 include("functor.jl")
 

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -29,7 +29,20 @@ macro functor(args...)
   functorm(args...)
 end
 
-isleaf(x) = functor(x)[1] === ()
+"""
+    isleaf(x)
+
+Return true if `x` has no [`children`](@ref) according to [`functor`](@ref).
+"""
+isleaf(x) = children(x) === ()
+
+"""
+    children(x)
+
+Return the children of `x` as defined by [`functor`](@ref).
+Equivalent to `functor(x)[1]`.
+"""
+children(x) = functor(x)[1]
 
 function fmap1(f, x)
   func, re = functor(x)
@@ -65,7 +78,7 @@ function fcollect(x; cache = [],
                      f = (v, vs) -> v)
 
   x in cache && return cache
-  vs = functor(x)[1]
+  vs = children(x)
   recurse(x, vs) || return cache
   push!(cache, f(x, vs))
   foreach(y -> fcollect(y; cache=cache, recurse=recurse, f=f), vs)

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -42,3 +42,37 @@ function fmap(f, x; cache = IdDict())
   haskey(cache, x) && return cache[x]
   cache[x] = isleaf(x) ? f(x) : fmap1(x -> fmap(f, x, cache = cache), x)
 end
+
+"""
+    fcollect(x; 
+             recurse = (v, vs) -> true, 
+             f = (v, vs) -> v)
+
+Traverse `x` recursively through the children defined by [`functor`](@ref)
+and return an array containing each node encountered.
+
+Doesn't recurse inside branches rooted at nodes `v` with children `vs` 
+for which `recurse(v, vs) == false`.
+In such cases, the root `v` is also excluded from the result.
+Per default, `recurse` yield always true. 
+
+Doesn't recurse inside branches rooted at nodes `v` with children `vs` 
+for which `recurse(v, vs) == false`.
+In such cases, the root `v` is also excluded from the result.
+Per default, `recurse` yield always true. 
+
+A function `f(v, vs)`, taking in input a node and its children, 
+can optionally be passed, so that the returned array will contain
+`f(v, vs)` instead of `v`. 
+"""
+function fcollect(x; cache = [], 
+                     recurse = (v, vs) -> true, 
+                     f = (v, vs) -> v)
+
+  x in cache && return cache
+  vs = functor(x)[1]
+  recurse(x, vs) || return cache
+  push!(cache, f(x, vs))
+  foreach(y -> fcollect(y; cache=cache, recurse=recurse, f=f), vs)
+  return cache
+end

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -57,23 +57,23 @@ function fmap(f, x; cache = IdDict())
 end
 
 """
-    fcollect(x; recurse = v -> true)
+    fcollect(x; exclude = v -> false)
 
 Traverse `x` by recursing each child of `x` as defined by [`functor`](@ref)
 and collecting the results into a flat array.
 
 Doesn't recurse inside branches rooted at nodes `v`
-for which `recurse(v) == false`.
+for which `exclude(v) == true`.
 In such cases, the root `v` is also excluded from the result.
-By default, `recurse` always yields true. 
+By default, `exclude` always yields `false`. 
 
 See also [`children`](@ref).
 """
-function fcollect(x; cache = [], recurse = v -> true)
+function fcollect(x; cache = [], exclude = v -> false)
   x in cache && return cache
-  if recurse(x)
+  if !exclude(x)
     push!(cache, x)
-    foreach(y -> fcollect(y; cache=cache, recurse=recurse), children(x))
+    foreach(y -> fcollect(y; cache=cache, exclude=exclude), children(x))
   end
   return cache
 end

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -61,17 +61,16 @@ end
              recurse = (v, vs) -> true, 
              f = (v, vs) -> v)
 
-Traverse `x` recursively through the children defined by [`functor`](@ref)
-and return an array containing each node encountered.
+Traverse `x` by recursing each child of `x` as defined by [`functor`](@ref),
+applying `f` to each node, and collecting the results into a flat array.
 
 Doesn't recurse inside branches rooted at nodes `v` with children `vs` 
 for which `recurse(v, vs) == false`.
 In such cases, the root `v` is also excluded from the result.
-Per default, `recurse` always yields true. 
+By default, `recurse` always yields true. 
 
-Optionally, a function `f(v, vs)` taking in input a node and its children 
-can  be passed, so that the returned array will contain
-`f(v, vs)` instead of `v`. 
+`f` should accept the inputs `(v, vs)` corresponding to the node
+and its children, respectively.
 """
 function fcollect(x; cache = [], 
                      recurse = (v, vs) -> true, 

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -106,7 +106,7 @@ function fcollect(x; cache = [], exclude = v -> false)
   x in cache && return cache
   if !exclude(x)
     push!(cache, x)
-    foreach(y -> fcollect(y; cache=cache, exclude=exclude), children(x))
+    foreach(y -> fcollect(y; cache = cache, exclude = exclude), children(x))
   end
   return cache
 end

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -54,15 +54,10 @@ and return an array containing each node encountered.
 Doesn't recurse inside branches rooted at nodes `v` with children `vs` 
 for which `recurse(v, vs) == false`.
 In such cases, the root `v` is also excluded from the result.
-Per default, `recurse` yield always true. 
+Per default, `recurse` always yields true. 
 
-Doesn't recurse inside branches rooted at nodes `v` with children `vs` 
-for which `recurse(v, vs) == false`.
-In such cases, the root `v` is also excluded from the result.
-Per default, `recurse` yield always true. 
-
-A function `f(v, vs)`, taking in input a node and its children, 
-can optionally be passed, so that the returned array will contain
+Optionally, a function `f(v, vs)` taking in input a node and its children 
+can  be passed, so that the returned array will contain
 `f(v, vs)` instead of `v`. 
 """
 function fcollect(x; cache = [], 

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -57,29 +57,23 @@ function fmap(f, x; cache = IdDict())
 end
 
 """
-    fcollect(x; 
-             recurse = (v, vs) -> true, 
-             f = (v, vs) -> v)
+    fcollect(x; recurse = v -> true)
 
-Traverse `x` by recursing each child of `x` as defined by [`functor`](@ref),
-applying `f` to each node, and collecting the results into a flat array.
+Traverse `x` by recursing each child of `x` as defined by [`functor`](@ref)
+and collecting the results into a flat array.
 
-Doesn't recurse inside branches rooted at nodes `v` with children `vs` 
-for which `recurse(v, vs) == false`.
+Doesn't recurse inside branches rooted at nodes `v`
+for which `recurse(v) == false`.
 In such cases, the root `v` is also excluded from the result.
 By default, `recurse` always yields true. 
 
-`f` should accept the inputs `(v, vs)` corresponding to the node
-and its children, respectively.
+See also [`children`](@ref).
 """
-function fcollect(x; cache = [], 
-                     recurse = (v, vs) -> true, 
-                     f = (v, vs) -> v)
-
+function fcollect(x; cache = [], recurse = v -> true)
   x in cache && return cache
-  vs = children(x)
-  recurse(x, vs) || return cache
-  push!(cache, f(x, vs))
-  foreach(y -> fcollect(y; cache=cache, recurse=recurse, f=f), vs)
+  if recurse(x)
+    push!(cache, x)
+    foreach(y -> fcollect(y; cache=cache, recurse=recurse), children(x))
+  end
   return cache
 end

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -68,6 +68,39 @@ In such cases, the root `v` is also excluded from the result.
 By default, `exclude` always yields `false`. 
 
 See also [`children`](@ref).
+
+# Examples
+
+```jldoctest
+julia> struct Foo; x; y; end
+
+julia> @functor Foo
+
+julia> struct Bar; x; end
+
+julia> @functor Bar
+
+julia> struct NoChildren; x; y; end 
+
+julia> m = Foo(Bar([1,2,3]), NoChildren(:a, :b))
+
+julia> fcollect(m)
+4-element Vector{Any}:
+ Foo(Bar([1, 2, 3]), NoChildren(:a, :b))
+ Bar([1, 2, 3])
+ [1, 2, 3]
+ NoChildren(:a, :b)
+
+julia> fcollect(m, exclude = v -> v isa Bar)
+2-element Vector{Any}:
+ Foo(Bar([1, 2, 3]), NoChildren(:a, :b))
+ NoChildren(:a, :b)
+ 
+julia> fcollect(m, exclude = v -> Functors.isleaf(v))
+2-element Vector{Any}:
+ Foo(Bar([1, 2, 3]), NoChildren(:a, :b))
+ Bar([1, 2, 3])
+```
 """
 function fcollect(x; cache = [], exclude = v -> false)
   x in cache && return cache

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -37,5 +37,5 @@ end
 
 @testset "Nested" begin
   model = Bar(Foo(1, [1, 2, 3]))
-  @show fcollect(model)
+  @test fcollect(model) == [Bar(Foo(1, [1, 2, 3])), Foo(1, [1, 2, 3]), 1, [1, 2, 3]]
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -34,8 +34,12 @@ end
   @test (model′.x, model′.y, model′.z) == (1, 4, 3)
 end
 
-
-@testset "Nested" begin
-  model = Bar(Foo(1, [1, 2, 3]))
-  @test fcollect(model) == [Bar(Foo(1, [1, 2, 3])), Foo(1, [1, 2, 3]), 1, [1, 2, 3]]
+@testset "fcollect" begin
+  m1 = [1, 2, 3]
+  m2 = 1
+  m3 = Foo(m1, m2)
+  m4 = Bar(m3)
+  @test all(fcollect(m4) .=== [m4, m3, m1, m2])
+  @test all(fcollect(m4, exclude = x -> x isa Array) .=== [m4, m3, m2])
+  @test all(fcollect(m4, exclude = x -> x isa Foo) .=== [m4])
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -50,7 +50,9 @@ end
 
   m1 = [1, 2, 3]
   m2 = Bar(m1)
-  m3 = Foo(m2, NoChildren(:a, :b))
+  m0 = NoChildren(:a, :b)
+  m3 = Foo(m2, m0)
   m4 = Bar(m3)
-  @test all(fcollect(m4) .=== [m4, m3, m2, m1])
+  println(fcollect(m4))
+  @test all(fcollect(m4) .=== [m4, m3, m2, m1, m0])
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -18,6 +18,11 @@ struct Baz
 end
 @functor Baz (y,)
 
+struct NoChildren 
+  x
+  y
+end
+
 @testset "Nested" begin
   model = Bar(Foo(1, [1, 2, 3]))
 
@@ -42,4 +47,10 @@ end
   @test all(fcollect(m4) .=== [m4, m3, m1, m2])
   @test all(fcollect(m4, exclude = x -> x isa Array) .=== [m4, m3, m2])
   @test all(fcollect(m4, exclude = x -> x isa Foo) .=== [m4])
+
+  m1 = [1, 2, 3]
+  m2 = Bar(m1)
+  m3 = Foo(m2, NoChildren(:a, :b))
+  m4 = Bar(m3)
+  @test all(fcollect(m4) .=== [m4, m3, m2, m1])
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -1,19 +1,24 @@
 using Functors, Test
 
+struct Foo
+  x
+  y
+end
+@functor Foo
+
+struct Bar
+  x
+end
+@functor Bar
+
+struct Baz
+  x
+  y
+  z
+end
+@functor Baz (y,)
+
 @testset "Nested" begin
-  struct Foo
-    x
-    y
-  end
-
-  @functor Foo
-
-  struct Bar
-    x
-  end
-
-  @functor Bar
-
   model = Bar(Foo(1, [1, 2, 3]))
 
   model′ = fmap(float, model)
@@ -22,17 +27,15 @@ using Functors, Test
   @test model′.x.y isa Vector{Float64}
 end
 
-@testset "Property list" begin
-  struct Baz
-    x
-    y
-    z
-  end
-  
-  @functor Baz (y,)
-  
+@testset "Property list" begin  
   model = Baz(1, 2, 3)
   model′ = fmap(x -> 2x, model)
   
   @test (model′.x, model′.y, model′.z) == (1, 4, 3)
+end
+
+
+@testset "Nested" begin
+  model = Bar(Foo(1, [1, 2, 3]))
+  @show fcollect(model)
 end


### PR DESCRIPTION
Follow up to the discussion in https://github.com/FluxML/Flux.jl/pull/1444.

I tried to give maximum flexibility to the interface. 

Notice  that it makes sense to pass a 2-args function `f(v, vs)` instead of a 1-arg `f(v)`, this is because applying a 1-arg `f` is quite simple a-posteriori
```julia
f.(fcollect(m))
```
Possible applications:
- Retrieve leaves from a model:
```julia
filter(isleaf, fcollect(m))
```
- Retrieve all nodes except leaves
```julia
filter(!isleaf, fcollect(m))
# or
fcollect(m; recur = (v, vs) -> !isleaf(v))
```
- Retrieve parents with all leaf children
```julia
a = fcollect(m; f = (v, vs) -> all(isleaf, vs) ? v : nothing)
filter(!isnothing, a)
``` 