### PR TITLE
fmapstructure

### DIFF
--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -2,7 +2,7 @@ module Functors
 
 using MacroTools
 
-export @functor, fmap, fcollect
+export @functor, fmap, fmapstructure, fcollect
 
 include("functor.jl")
 

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -50,15 +50,15 @@ function _default_walk(f, x)
 end
 
 """
-    fmap(f, x; exclude = isleaf, walk = (f′, x) -> ...)
+    fmap(f, x; exclude = isleaf, walk = Functors._default_walk)
 
 A structure and type preserving `map` that works for all [`functor`](@ref)s.
 
 By default, traveres `x` recursively using [`functor`](@ref)
 and transforms every leaf node identified by `exclude` with `f`.
 
-For advanced customization of the traversal behaviour, pass a custom `walk` function.
-This function must itself call the continuation f′ to continue traversal.
+For advanced customization of the traversal behaviour, pass a custom `walk` function of the form `(f', xs) -> ...`.
+This function walks (maps) over `xs` calling the continuation `f'` to continue traversal.
 
 # Examples
 ```jldoctest
@@ -93,9 +93,9 @@ end
 """
     fmapstructure(f, x; exclude = isleaf)
 
-Like [`fmap`](@ref), but doesn't preserve the type of custom structs.
+Like [`fmap`](@ref), but doesn't preserve the type of custom structs. Instead, it returns a (potentially nested) `NamedTuple`.
 
-Useful for when the output must be plain-old julia data structures.
+Useful for when the output must not contain custom structs.
 
 # Examples
 ```jldoctest
@@ -109,7 +109,7 @@ julia> fmapstructure(x -> 2x, m)
 (x = [2, 4, 6], y = (8, 10))
 ```
 """
-fmapstructure(f, x; kwargs...) = fmap(f, x; walk=(f, x) -> map(f, children(x)), kwargs...)
+fmapstructure(f, x; kwargs...) = fmap(f, x; walk = (f, x) -> map(f, children(x)), kwargs...)
 
 """
     fcollect(x; exclude = v -> false)

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -54,7 +54,7 @@ end
 
 A structure and type preserving `map` that works for all [`functor`](@ref)s.
 
-By default, traveres `x` recursively using [`functor`](@ref)
+By default, traverses `x` recursively using [`functor`](@ref)
 and transforms every leaf node identified by `exclude` with `f`.
 
 For advanced customization of the traversal behaviour, pass a custom `walk` function of the form `(f', xs) -> ...`.
@@ -80,6 +80,9 @@ Foo(Bar("[1, 2, 3]"), ("4", "5"))
 
 julia> fmap(string, m, exclude = v -> v isa Bar)
 Foo("Bar([1, 2, 3])", (4, 5))
+
+julia> fmap(x -> 2x, m, walk=(f, x) -> x isa Bar ? x : Functors._default_walk(f, x))
+Foo(Bar([1, 2, 3]), (8, 10))
 ```
 """
 function fmap(f, x; exclude = isleaf, walk = _default_walk, cache = IdDict())

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -45,6 +45,13 @@ end
   @test fmap(f, x; exclude = x -> x isa AbstractArray) == x
 end
 
+@testset "Walk" begin
+  model = Foo((0, Bar([1, 2, 3])), [4, 5])
+
+  model′ = fmapstructure(identity, model)
+  @test model′ == (; x=(0, (; x=[1, 2, 3])), y=[4, 5])
+end
+
 @testset "Property list" begin
   model = Baz(1, 2, 3)
   model′ = fmap(x -> 2x, model)


### PR DESCRIPTION
Example usage:
```julia
m = Chain(Dense(10, 5), Dense(5, 2))

functorize(identity, m) |> typeof
# Tuple{NamedTuple{(:weight, :bias, :σ), Tuple{Matrix{Float32}, Vector{Float32}, typeof(identity)}}, NamedTuple{(:weight, :bias, :σ), Tuple{Matrix{Float32}, Vector{Float32}, typeof(identity)}}}

# Similar output to what you get from explicit gradients
functorize(x -> x isa AbstractArray ? x : nothing, m) |> typeof
# Tuple{NamedTuple{(:weight, :bias, :σ), Tuple{Matrix{Float32}, Vector{Float32}, Nothing}}, NamedTuple{(:weight, :bias, :σ), Tuple{Matrix{Float32}, Vector{Float32}, Nothing}}}
```
Note how the implementation is almost exactly the same as `fmap`, just without the `re`(construction). Ideally this functionality could be folded into `fmap` itself, but I'm not sure what the most elegant way to conditionally control reconstruct is.

cc @DhairyaLGandhi @darsnack 