### PR TITLE
FlexibleFunctors

### DIFF
--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -2,7 +2,7 @@ module Functors
 
 using MacroTools
 
-export @functor, fmap, fmapstructure, fcollect
+export @functor, @flexiblefunctor, fmap, fmapstructure, fcollect
 
 include("functor.jl")
 

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -32,15 +32,13 @@ end
 function makeflexiblefunctor(m::Module, T, pfield)
   pfield = QuoteNode(pfield)
   @eval m begin
-    $Functors.functor(::Type{<:$T}, x) = begin
+    function $Functors.functor(::Type{<:$T}, x)
+      pfields = getproperty(x, $pfield)
       function re(y)
-        all_args = map(fieldnames($T)) do fn
-          field = fn in getfield(x, $pfield) ? getfield(y, fn) : getfield(x, fn)
-          return field
-        end
+        all_args = map(fn -> getproperty(fn in pfields ? y : x, fn), fieldnames($T))
         return $T(all_args...)
       end
-      func = NamedTuple{pfields}(map(p -> getfield(x, p), pfields))
+      func = NamedTuple{pfields}(map(p -> getproperty(x, p), pfields))
       return func, re
     end
 

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -40,7 +40,7 @@ function makeflexiblefunctor(m::Module, T, pfield)
         end
         return $T(all_args...)
       end
-      func = (; (p => getfield(x, p) for p in getfield(x, $pfield))...)
+      func = NamedTuple{pfields}(map(p -> getfield(x, p), pfields))
       return func, re
     end
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -73,7 +73,6 @@ end
   m0 = NoChildren(:a, :b)
   m3 = Foo(m2, m0)
   m4 = Bar(m3)
-  println(fcollect(m4))
   @test all(fcollect(m4) .=== [m4, m3, m2, m1, m0])
 end
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -76,3 +76,69 @@ end
   println(fcollect(m4))
   @test all(fcollect(m4) .=== [m4, m3, m2, m1, m0])
 end
+
+struct FFoo
+  x
+  y
+  p
+end
+@flexiblefunctor FFoo p
+
+struct FBar
+  x
+  p
+end
+@flexiblefunctor FBar p
+
+struct FBaz
+  x
+  y
+  z
+  p
+end
+@flexiblefunctor FBaz p
+
+@testset "Flexible Nested" begin
+  model = FBar(FFoo(1, [1, 2, 3], (:y, )), (:x,))
+
+  model′ = fmap(float, model)
+
+  @test model.x.y == model′.x.y
+  @test model′.x.y isa Vector{Float64}
+end
+
+@testset "Flexible Walk" begin
+  model = FFoo((0, FBar([1, 2, 3], (:x,))), [4, 5], (:x, :y))
+
+  model′ = fmapstructure(identity, model)
+  @test model′ == (; x=(0, (; x=[1, 2, 3])), y=[4, 5])
+
+  model2 = FFoo((0, FBar([1, 2, 3], (:x,))), [4, 5], (:x,))
+
+  model2′ = fmapstructure(identity, model2)
+  @test model2′ == (; x=(0, (; x=[1, 2, 3])))
+end
+
+@testset "Flexible Property list" begin
+  model = FBaz(1, 2, 3, (:x, :z))
+  model′ = fmap(x -> 2x, model)
+
+  @test (model′.x, model′.y, model′.z) == (2, 2, 6)
+end
+
+@testset "Flexible fcollect" begin
+  m1 = 1
+  m2 = [1, 2, 3]
+  m3 = FFoo(m1, m2, (:y, ))
+  m4 = FBar(m3, (:x,))
+  @test all(fcollect(m4) .=== [m4, m3, m2])
+  @test all(fcollect(m4, exclude = x -> x isa Array) .=== [m4, m3])
+  @test all(fcollect(m4, exclude = x -> x isa FFoo) .=== [m4])
+
+  m0 = NoChildren(:a, :b)
+  m1 = [1, 2, 3]
+  m2 = FBar(m1, ())
+  m3 = FFoo(m2, m0, (:x, :y,))
+  m4 = FBar(m3, (:x,))
+  @test all(fcollect(m4) .=== [m4, m3, m2, m0])
+end


### PR DESCRIPTION
This PR is a partial port of [FlexibleFunctors.jl]( https://github.com/Metalenz/FlexibleFunctors.jl), following feedback from @ToucheSir on [this](https://discourse.julialang.org/t/ann-flexiblefunctors-jl-functors-with-per-instance-parameters/64935) Discourse post.

This proposes the `@flexiblefunctor T param_field` syntax for defining a `flexiblefunctor`, or a `functor` with parameters tagged in an internal `Tuple` field, as opposed to a global set of parameters. This enables different instances of a type to have different parameter fields, such as two `Foo` instances where `Foo1.x` is a parameter and `Foo2.y` is a parameter, but `Foo1.y` and `Foo2.x` are not. 

I've reproduced the `@functor` tests (with some modifications to demonstrate flexibility) to demonstrate consistency with the existing framework as well.

This is not a complete 1:1 port from `FlexibleFunctors.jl`. `FlexibleFunctors.jl` actually defines a new function which operates on a type to determine its parameter fields, and for each type this function needed a new method. In practice, we typically store parameters in a field within the struct, so I don't think this feature is a meaningful loss for now.