### PR TITLE
Extract common functionality into fold

### DIFF
--- a/test/basics.jl
+++ b/test/basics.jl
@@ -72,8 +72,8 @@ end
   m2 = 1
   m3 = Foo(m1, m2)
   m4 = Bar(m3)
-  @test all(fcollect(m4) .=== [m4, m3, m1, m2])
-  @test all(fcollect(m4, exclude = x -> x isa Array) .=== [m4, m3, m2])
+  @test all(fcollect(m4) .=== [m1, m2, m3, m4])
+  @test all(fcollect(m4, exclude = x -> x isa Array) .=== [m2, m3, m4])
   @test all(fcollect(m4, exclude = x -> x isa Foo) .=== [m4])
 
   m1 = [1, 2, 3]
@@ -81,12 +81,12 @@ end
   m0 = NoChildren(:a, :b)
   m3 = Foo(m2, m0)
   m4 = Bar(m3)
-  @test all(fcollect(m4) .=== [m4, m3, m2, m1, m0])
+  @test all(fcollect(m4) .=== [m1, m2, m0, m3, m4])
 
   m1 = [1, 2, 3]
   m2 = [1, 2, 3]
   m3 = Foo(m1, m2)
-  @test all(fcollect(m3) .=== [m3, m1, m2])
+  @test all(fcollect(m3) .=== [m1, m2, m3])
 end
 
 struct FFoo
@@ -143,8 +143,8 @@ end
   m2 = [1, 2, 3]
   m3 = FFoo(m1, m2, (:y, ))
   m4 = FBar(m3, (:x,))
-  @test all(fcollect(m4) .=== [m4, m3, m2])
-  @test all(fcollect(m4, exclude = x -> x isa Array) .=== [m4, m3])
+  @test all(fcollect(m4) .=== [m2, m3, m4])
+  @test all(fcollect(m4, exclude = x -> x isa Array) .=== [m3, m4])
   @test all(fcollect(m4, exclude = x -> x isa FFoo) .=== [m4])
 
   m0 = NoChildren(:a, :b)
@@ -152,5 +152,5 @@ end
   m2 = FBar(m1, ())
   m3 = FFoo(m2, m0, (:x, :y,))
   m4 = FBar(m3, (:x,))
-  @test all(fcollect(m4) .=== [m4, m3, m2, m0])
+  @test all(fcollect(m4) .=== [m2, m0, m3, m4])
 end


### PR DESCRIPTION
Traversal functions in Functors.jl currently handle traversal via manual recursion. This isn't the end of the world, but it results in a good amount of code duplication as well as parameter explosion from having to plumb auxiliary arguments through the call stack. With #31 looking to add a number of additional functions and Optimisers.jl not getting a lot of mileage out of `fmap`, it's a good time to consider whether we can cut down on the boilerplate.

This PR introduces helper traversal functionality in the form of `[fF]old`. In the language of [recursion schemes](https://blog.sumtypeofway.com/posts/introduction-to-recursion-schemes.html), `fold` is a "catamorphism" which performs a generalized structural reduction over a tree (or in our case, DAG).

This is the first step in an effort to implement the vision of #27 while maintaining as much backwards compatibility as possible. A non-exhaustive list of objectives for future PRs include:
1. Reducing the reliance on custom walks for downstream code
2. Removing the requirement to carry around the `re`(construct) closure. This can lead to some unfortunate gymnastics, so getting rid of it would be great.
3. Accomodating multiple inputs, e.g. `fmap(f, x, xs...)`. This would help Optimisers.jl and any other downstream library that have rolled their own `fmap` variants with `functor`.