### PR TITLE
Functor `Transpose` et. al.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
           - '1.6' # Replace this with the minimum Julia version that your package supports.
           - '1'   # automatically expands to the latest stable 1.x release of Julia
           - 'nightly'

--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,14 @@
 name = "Functors"
 uuid = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
 authors = ["Mike J Innes <mike.j.innes@gmail.com>"]
-version = "0.2.8"
+version = "0.3.0"
+
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 Documenter = "0.27"
-julia = "1"
+julia = "1.6"
 
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -23,7 +23,6 @@ usually using the macro [`@functor`](@ref).
 """
 functor
 
-@static if VERSION >= v"1.5"  # var"@functor" doesn't work on 1.0, temporarily disable
 @doc """
     @functor T
     @functor T (x,)
@@ -66,7 +65,6 @@ TwoThirds(Foo(10, 20), Foo(3, 4), 560)
 ```
 """
 var"@functor"
-end  # VERSION
 
 """
     Functors.isleaf(x)

--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -138,15 +138,13 @@ julia> fmap(println, (i = twice, ii = 34, iii = [5, 6], iv = (twice, 34), v = 34
 [1, 2]
 34
 [5, 6]
-34
 34.0
 (i = nothing, ii = nothing, iii = nothing, iv = (nothing, nothing), v = nothing)
 ```
 
-If the same object appears more than once, it will only be handled once, and only be 
-transformed once with `f`. Thus the result will also have this relationship.
-Here "same" means `===` for non-`isbits` types. The same number (e.g. `34 === 34`) at
-different nodes is taken to be a coincidence, and `f` applies twice.
+If the same node (same according to `===`) appears more than once,
+it will only be handled once, and only be transformed once with `f`.
+Thus the result will also have this relationship.
 
 By default, `Tuple`s, `NamedTuple`s, and some other container-like types in Base have
 children to recurse into. Arrays of numbers do not.

--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -140,13 +140,15 @@ julia> fmap(println, (i = twice, ii = 34, iii = [5, 6], iv = (twice, 34), v = 34
 [1, 2]
 34
 [5, 6]
+34
 34.0
 (i = nothing, ii = nothing, iii = nothing, iv = (nothing, nothing), v = nothing)
 ```
 
-If the same node (same according to `===`) appears more than once,
-it will only be handled once, and only be transformed once with `f`.
-Thus the result will also have this relationship.
+If the same object appears more than once, it will only be handled once, and only be 
+transformed once with `f`. Thus the result will also have this relationship.
+Here "same" means `===` for non-`isbits` types. The same number (e.g. `34 === 34`) at
+different nodes is taken to be a coincidence, and `f` applies twice.
 
 By default, `Tuple`s, `NamedTuple`s, and some other container-like types in Base have
 children to recurse into. Arrays of numbers do not.

--- a/src/base.jl
+++ b/src/base.jl
@@ -3,6 +3,10 @@
 
 functor(::Type{<:Base.ComposedFunction}, x) = (outer = x.outer, inner = x.inner), y -> Base.ComposedFunction(y.outer, y.inner)
 
+###
+### Array wrappers
+###
+
 using LinearAlgebra
 # The reason for these is to let W and W' be seen as tied weights in Flux models.
 # Can't treat ReshapedArray very well, as its type doesn't include enough details for reconstruction.
@@ -19,6 +23,9 @@ _transpose(x) = transpose(x)
 _transpose(x::NamedTuple{(:parent,)}) = x.parent
 _transpose(bc::Broadcast.Broadcasted{S}) where S = Broadcast.Broadcasted{S}(_conjugate(bc.f, transpose), _transpose.(bc.args))
 
+_conjugate(f::F, ::typeof(identity)) where F = f
+_conjugate(f::F, op::Union{typeof(transpose), typeof(adjoint)}) where F = (xs...,) -> op(f(op.(xs)...))
+
 function functor(::Type{<:PermutedDimsArray{T,N,perm,iperm}}, x) where {T,N,perm,iperm}
   (parent = _PermutedDimsArray(x, iperm),), y -> PermutedDimsArray(only(y), perm)
 end
@@ -29,6 +36,3 @@ end
 _PermutedDimsArray(x, iperm) = PermutedDimsArray(x, iperm)
 _PermutedDimsArray(x::NamedTuple{(:parent,)}, iperm) = x.parent
 _PermutedDimsArray(bc::Broadcast.Broadcasted, iperm) = _PermutedDimsArray(Broadcast.materialize(bc), iperm)
-
-_conjugate(f::F, ::typeof(identity)) where F = f
-_conjugate(f::F, op::Union{typeof(transpose), typeof(adjoint)}) where F = (xs...,) -> op(f(op.(xs)...))

--- a/src/base.jl
+++ b/src/base.jl
@@ -1,1 +1,34 @@
+
 @functor Base.RefValue
+
+functor(::Type{<:Base.ComposedFunction}, x) = (outer = x.outer, inner = x.inner), y -> Base.ComposedFunction(y.outer, y.inner)
+
+using LinearAlgebra
+# The reason for these is to let W and W' be seen as tied weights in Flux models.
+# Can't treat ReshapedArray very well, as its type doesn't include enough details for reconstruction.
+
+functor(::Type{<:Adjoint}, x) = (parent = _adjoint(x),), y -> adjoint(only(y))
+
+_adjoint(x) = adjoint(x)  # _adjoint is the inverse, and also understands more types:
+_adjoint(x::NamedTuple{(:parent,)}) = x.parent  # "structural" gradient, and lazy broadcast used by Optimisers:
+_adjoint(bc::Broadcast.Broadcasted{S}) where S = Broadcast.Broadcasted{S}(_conjugate(bc.f, adjoint), _adjoint.(bc.args))
+
+functor(::Type{<:Transpose}, x) = (parent = _transpose(x),), y -> transpose(only(y))
+
+_transpose(x) = transpose(x)
+_transpose(x::NamedTuple{(:parent,)}) = x.parent
+_transpose(bc::Broadcast.Broadcasted{S}) where S = Broadcast.Broadcasted{S}(_conjugate(bc.f, transpose), _transpose.(bc.args))
+
+function functor(::Type{<:PermutedDimsArray{T,N,perm,iperm}}, x) where {T,N,perm,iperm}
+  (parent = _PermutedDimsArray(x, iperm),), y -> PermutedDimsArray(only(y), perm)
+end
+function functor(::Type{<:PermutedDimsArray{T,N,perm,iperm}}, x::PermutedDimsArray{Tx,N,perm,iperm}) where {T,Tx,N,perm,iperm}
+  (parent = parent(x),), y -> PermutedDimsArray(only(y), perm)  # most common case, avoid wrapping wrice.
+end
+
+_PermutedDimsArray(x, iperm) = PermutedDimsArray(x, iperm)
+_PermutedDimsArray(x::NamedTuple{(:parent,)}, iperm) = x.parent
+_PermutedDimsArray(bc::Broadcast.Broadcasted, iperm) = _PermutedDimsArray(Broadcast.materialize(bc), iperm)
+
+_conjugate(f::F, ::typeof(identity)) where F = f
+_conjugate(f::F, op::Union{typeof(transpose), typeof(adjoint)}) where F = (xs...,) -> op(f(op.(xs)...))

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -43,25 +43,11 @@ function _default_walk(f, x)
   re(map(f, func))
 end
 
-usecache(x) = !isbits(x)
-usecache(x::Union{String, Symbol}) = false
-
 struct NoKeyword end
 
-function fmap(f, x; exclude = isleaf, walk = _default_walk, cache = usecache(x) ? IdDict() : nothing, prune = NoKeyword())
-  if exclude(x)
-    if usecache(x)
-      if haskey(cache, x)
-        prune isa NoKeyword ? cache[x] : prune
-      else
-        cache[x] = f(x)
-      end
-    else
-      f(x)
-    end
-  else
-    walk(x -> fmap(f, x; exclude = exclude, walk = walk, cache = cache, prune = prune), x)
-  end
+function fmap(f, x; exclude = isleaf, walk = _default_walk, cache = IdDict(), prune = NoKeyword())
+  haskey(cache, x) && return prune isa NoKeyword ? cache[x] : prune
+  cache[x] = exclude(x) ? f(x) : walk(x -> fmap(f, x; exclude=exclude, walk=walk, cache=cache, prune=prune), x)
 end
 
 ###
@@ -87,20 +73,9 @@ end
 ### Vararg forms
 ###
 
-function fmap(f, x, ys...; exclude = isleaf, walk = _default_walk, cache = usecache(x) ? IdDict() : nothing, prune = NoKeyword())
-  if exclude(x)
-    if usecache(x)
-      if haskey(cache, x)
-        prune isa NoKeyword ? cache[x] : prune
-      else
-        cache[x] = f(x, ys...)
-      end
-    else
-      f(x, ys...)
-    end
-  else
-    walk((xy...,) -> fmap(f, xy...; exclude = exclude, walk = walk, cache = cache, prune = prune), x, ys...)
-  end
+function fmap(f, x, ys...; exclude = isleaf, walk = _default_walk, cache = IdDict(), prune = NoKeyword())
+  haskey(cache, x) && return prune isa NoKeyword ? cache[x] : prune
+  cache[x] = exclude(x) ? f(x, ys...) : walk((xy...,) -> fmap(f, xy...; exclude=exclude, walk=walk, cache=cache, prune=prune), x, ys...)
 end
 
 function _default_walk(f, x, ys...)

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -8,10 +8,6 @@ functor(::Type{<:NamedTuple{L}}, x) where L = NamedTuple{L}(map(s -> getproperty
 functor(::Type{<:AbstractArray}, x) = x, y -> y
 functor(::Type{<:AbstractArray{<:Number}}, x) = (), _ -> x
 
-@static if VERSION >= v"1.6"
-  functor(::Type{<:Base.ComposedFunction}, x) = (outer = x.outer, inner = x.inner), y -> Base.ComposedFunction(y.outer, y.inner)
-end
-
 function makefunctor(m::Module, T, fs = fieldnames(T))
   yᵢ = 0
   escargs = map(fieldnames(T)) do f

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -44,14 +44,24 @@ function _default_walk(f, x)
 end
 
 usecache(x) = !isbits(x)
+usecache(x::Union{String, Symbol}) = false
 
 struct NoKeyword end
 
 function fmap(f, x; exclude = isleaf, walk = _default_walk, cache = usecache(x) ? IdDict() : nothing, prune = NoKeyword())
-  usecache(x) && haskey(cache, x) && return prune isa NoKeyword ? cache[x] : prune
-  xnew = exclude(x) ? f(x) : walk(x -> fmap(f, x; exclude=exclude, walk=walk, cache=cache, prune=prune), x)
-  usecache(x) && setindex!(cache, xnew, x)
-  return xnew
+  if exclude(x)
+    if usecache(x)
+      if haskey(cache, x)
+        prune isa NoKeyword ? cache[x] : prune
+      else
+        cache[x] = f(x)
+      end
+    else
+      f(x)
+    end
+  else
+    walk(x -> fmap(f, x; exclude = exclude, walk = walk, cache = cache, prune = prune), x)
+  end
 end
 
 ###
@@ -77,11 +87,20 @@ end
 ### Vararg forms
 ###
 
-function fmap(f, x, ys...; exclude = isleaf, walk = _default_walk, cache = IdDict(), prune = NoKeyword())
-  usecache(x) && haskey(cache, x) && return prune isa NoKeyword ? cache[x] : prune
-  xnew = exclude(x) ? f(x, ys...) : walk((xy...,) -> fmap(f, xy...; exclude=exclude, walk=walk, cache=cache, prune=prune), x, ys...)
-  usecache(x) && setindex!(cache, xnew, x)
-  return xnew
+function fmap(f, x, ys...; exclude = isleaf, walk = _default_walk, cache = usecache(x) ? IdDict() : nothing, prune = NoKeyword())
+  if exclude(x)
+    if usecache(x)
+      if haskey(cache, x)
+        prune isa NoKeyword ? cache[x] : prune
+      else
+        cache[x] = f(x, ys...)
+      end
+    else
+      f(x, ys...)
+    end
+  else
+    walk((xy...,) -> fmap(f, xy...; exclude = exclude, walk = walk, cache = cache, prune = prune), x, ys...)
+  end
 end
 
 function _default_walk(f, x, ys...)

--- a/test/base.jl
+++ b/test/base.jl
@@ -10,14 +10,12 @@
   @test re(p) isa Base.RefValue{Int}
 end
 
-@static if VERSION >= v"1.6"
-  @testset "ComposedFunction" begin
-    f1 = Foo(1.1, 2.2)
-    f2 = Bar(3.3)
-    @test Functors.functor(f1 ∘ f2)[1] == (outer = f1, inner = f2)
-    @test Functors.functor(f1 ∘ f2)[2]((outer = f1, inner = f2)) == f1 ∘ f2
-    @test fmap(x -> x + 10, f1 ∘ f2) == Foo(11.1, 12.2) ∘ Bar(13.3)
-  end
+@testset "ComposedFunction" begin
+  f1 = Foo(1.1, 2.2)
+  f2 = Bar(3.3)
+  @test Functors.functor(f1 ∘ f2)[1] == (outer = f1, inner = f2)
+  @test Functors.functor(f1 ∘ f2)[2]((outer = f1, inner = f2)) == f1 ∘ f2
+  @test fmap(x -> x + 10, f1 ∘ f2) == Foo(11.1, 12.2) ∘ Bar(13.3)
 end
 
 @testset "PermutedDimsArray" begin

--- a/test/base.jl
+++ b/test/base.jl
@@ -1,8 +1,72 @@
-@testset "Base" begin
-    @testset "RefValue" begin
-        x = Ref(1)
-        p, re = Functors.functor(x)
-        @test p == (x = 1,)
-        @test re(p) isa Base.RefValue{Int}
-    end
+
+@testset "RefValue" begin
+  @test fmap(sqrt, Ref(16))[] == 4.0
+  @test fmap(sqrt, Ref(16)) isa Ref
+  @test fmapstructure(sqrt, Ref(16)) === (x = 4.0,)
+
+  x = Ref(1)
+  p, re = Functors.functor(x)
+  @test p == (x = 1,)
+  @test re(p) isa Base.RefValue{Int}
+end
+
+@static if VERSION >= v"1.6"
+  @testset "ComposedFunction" begin
+    f1 = Foo(1.1, 2.2)
+    f2 = Bar(3.3)
+    @test Functors.functor(f1 ∘ f2)[1] == (outer = f1, inner = f2)
+    @test Functors.functor(f1 ∘ f2)[2]((outer = f1, inner = f2)) == f1 ∘ f2
+    @test fmap(x -> x + 10, f1 ∘ f2) == Foo(11.1, 12.2) ∘ Bar(13.3)
+  end
+end
+
+@testset "PermutedDimsArray" begin
+  @test fmapstructure(identity, PermutedDimsArray([1 2; 3 4], (2,1))) == (parent = [1 2; 3 4],)
+  @test fmap(exp, PermutedDimsArray([1 2; 3 4], (2,1))) isa PermutedDimsArray{Float64}
+end
+
+@testset "LinearAlgebra containers" begin
+  @test fmapstructure(identity, [1,2,3]') == (parent = [1, 2, 3],)
+  @test fmapstructure(identity, transpose([1,2,3])) == (parent = [1, 2, 3],)
+
+  CNT = Ref(0)
+  fv(x::Vector) = (CNT[]+=1; 10v)
+
+  v = [1,2,3]
+  nt = fmap(fv, (a=v, b=v', c=transpose(v), d=[1,2,3]'))
+
+  @test nt.a === adjoint(nt.b)  # does not break tie
+  @test nt.a === transpose(nt.c)
+
+  @test CNT[] == 2
+  @test nt.a == adjoint(nt.d)  # does not create a new tie
+  @test nt.a !== adjoint(nt.d)
+
+  @test nt.b isa Adjoint
+  @test nt.c isa Transpose
+
+  x = [1,2,3]'
+  xs = fmapstructure(identity, x)  # check it digests this, e.g. structural gradient representation
+  @test Functors.functor(typeof(x), xs) == Functors.functor(x)  # (no real need for [2] types to match)
+
+  x = transpose([1 2; 3 4])
+  yt = transpose([5 6; 7 8])
+  ym = Matrix(yt)  # check it digests this, e.g. simplest Matrix gradient
+  @test Functors.functor(typeof(x), yt)[1].parent == Functors.functor(typeof(x), ym)[1].parent
+
+  ybc = Broadcast.broadcasted(+, ym, 9)  # check it digests this, as Optimisers.jl makes these
+  collect(ybc) isa Vector
+  zbc = Functors.functor(typeof(x), ybc)[1].parent
+  @test zbc .+ 0 == Functors.functor(typeof(x), ym .+ 9)[1].parent
+
+  # Similar checks for Adjoint. 
+  x = adjoint([1 2im 3; 4im 5 6im])
+  yt = adjoint([7im 8 9; 0 im 2])
+  ym = Matrix(yt)
+  @test Functors.functor(typeof(x), yt)[1].parent == Functors.functor(typeof(x), ym)[1].parent
+
+  ybc = Broadcast.broadcasted(+, ym, [11im, 12, im])
+  collect(ybc) isa Vector
+  zbc = Functors.functor(typeof(x), ybc)[1].parent
+  @test zbc .+ 0 == Functors.functor(typeof(x), ym .+ [11im, 12, im])[1].parent
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -198,7 +198,6 @@ end
   end
 end
 
-@static if VERSION >= v"1.6" # Julia 1.0: LoadError: error compiling top-level scope: type definition not allowed inside a local scope
 @testset "old test update.jl" begin
   struct M{F,T,S}
     σ::F
@@ -222,7 +221,6 @@ end
   @test m̂.W ≈ fill(0.8f0, size(m.W))
   @test m̂.b ≈ fill(-0.2f0, size(m.b))
 end
-end  # VERSION
 
 ###
 ### FlexibleFunctors.jl

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -14,16 +14,6 @@ struct NoChildren2; x; y; end
 
 struct NoChild{T}; x::T; end
 
-@static if VERSION >= v"1.6"
-  @testset "ComposedFunction" begin
-    f1 = Foo(1.1, 2.2)
-    f2 = Bar(3.3)
-    @test Functors.functor(f1 ∘ f2)[1] == (outer = f1, inner = f2)
-    @test Functors.functor(f1 ∘ f2)[2]((outer = f1, inner = f2)) == f1 ∘ f2
-    @test fmap(x -> x + 10, f1 ∘ f2) == Foo(11.1, 12.2) ∘ Bar(13.3)
-  end
-end
-
 ###
 ### Basic functionality
 ###

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -12,6 +12,8 @@ struct OneChild3; x; y; z; end
 
 struct NoChildren2; x; y; end
 
+struct NoChild{T}; x::T; end
+
 @static if VERSION >= v"1.6"
   @testset "ComposedFunction" begin
     f1 = Foo(1.1, 2.2)
@@ -64,13 +66,13 @@ end
   m1p = fmapstructure(identity, m1; prune = nothing)
   @test m1p == (x = [1, 2, 3], y = (x = [1, 2, 3], y = (x = nothing, y = [1, 2, 3])))
 
-  # A non-leaf node can also be repeated:
+  # The cache applies only to leaf nodes, so that "4" is not shared:
   m2 = Foo(Foo(shared, 4), Foo(shared, 4))
   @test m2.x === m2.y
   m2f = fmap(float, m2)
   @test m2f.x.x === m2f.y.x
   m2p = fmapstructure(identity, m2; prune = Bar(0))
-  @test m2p == (x = (x = [1, 2, 3], y = 4), y = Bar(0))
+  @test m2p == (x = (x = [1, 2, 3], y = 4), y = (x = Bar{Int64}(0), y = 4))
 
   # Repeated isbits types should not automatically be regarded as shared:
   m3 = Foo(Foo(shared, 1:3), Foo(1:3, shared))
@@ -83,15 +85,18 @@ end
   @test_skip 0 == @allocated fmap(float, (x=1, y=(2, 3), z=4:5))
 
   @testset "usecache" begin
+    # Leaf types:
     @test usecache([1,2])
-    @test usecache(Ref(3))
-
     @test !usecache(4.0)
+    @test usecache(NoChild([1,2]))
+    @test !usecache(NoChild((3,4)))
+
+    # Not leaf by default, but `exclude` can change that:
+    @test usecache(Ref(3))
     @test !usecache((5, 6.0))
     @test !usecache((a = 2pi, b = missing))
 
-    @test usecache(Bar([1,2]))
-    @test !usecache(Bar((3,4)))
+    @test usecache((x = [1,2,3], y = 4))
   end
 end
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -1,10 +1,10 @@
 
-using Functors: functor
+using Functors: functor, usecache
 
 struct Foo; x; y; end
 @functor Foo
 
-struct Bar; x; end
+struct Bar{T}; x::T; end
 @functor Bar
 
 struct OneChild3; x; y; z; end
@@ -76,7 +76,23 @@ end
   m3 = Foo(Foo(shared, 1:3), Foo(1:3, shared))
   m3p = fmapstructure(identity, m3; prune = 0)
   @test m3p.y.y == 0
-  @test_broken m3p.y.x == 1:3
+  @test m3p.y.x == 1:3
+
+  # All-isbits trees need not create a cache at all:
+  @test isbits(fmap(float, (x=1, y=(2, 3), z=4:5)))
+  @test_skip 0 == @allocated fmap(float, (x=1, y=(2, 3), z=4:5))
+
+  @testset "usecache" begin
+    @test usecache([1,2])
+    @test usecache(Ref(3))
+
+    @test !usecache(4.0)
+    @test !usecache((5, 6.0))
+    @test !usecache((a = 2pi, b = missing))
+
+    @test usecache(Bar([1,2]))
+    @test !usecache(Bar((3,4)))
+  end
 end
 
 @testset "functor(typeof(x), y) from @functor" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Functors, Test
 using Zygote
+using LinearAlgebra
 
 @testset "Functors.jl" begin
 


### PR DESCRIPTION
Part of #28. Better implementation than that in #31. 

There is some chance this will break Flux's current Params thing horribly, I should check.