### PR TITLE
Use the cache less often

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Functors"
 uuid = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
 authors = ["Mike J Innes <mike.j.innes@gmail.com>"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -5,7 +5,6 @@ export @functor, @flexiblefunctor, fmap, fmapstructure, fcollect
 include("functor.jl")
 include("base.jl")
 
-
 ###
 ### Docstrings for basic functionality
 ###
@@ -132,7 +131,7 @@ Any[23, (45,), (x = 6//7, y = ())]
 [8, 9]
 (a = nothing, b = nothing, c = nothing)
 
-julia> twice = [1, 2];
+julia> twice = [1, 2];  # println only acts once on this
 
 julia> fmap(println, (i = twice, ii = 34, iii = [5, 6], iv = (twice, 34), v = 34.0))
 [1, 2]
@@ -143,10 +142,10 @@ julia> fmap(println, (i = twice, ii = 34, iii = [5, 6], iv = (twice, 34), v = 34
 (i = nothing, ii = nothing, iii = nothing, iv = (nothing, nothing), v = nothing)
 ```
 
-If the same object appears more than once, it will only be handled once, and only be 
-transformed once with `f`. Thus the result will also have this relationship.
-Here "same" means `===` for non-`isbits` types. The same number (e.g. `34 === 34`) at
-different nodes is taken to be a coincidence, and `f` applies twice.
+Mutable objects which appear more than once are only handled once (by caching `f(x)` in an `IdDict`).
+Thus the relationship `x.i === x.iv[1]` will be preserved.
+An immutable object which appears twice is not stored in the cache, thus `f(34)` will be called twice,
+and the results will agree only if `f` is pure.
 
 By default, `Tuple`s, `NamedTuple`s, and some other container-like types in Base have
 children to recurse into. Arrays of numbers do not.

--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -138,13 +138,15 @@ julia> fmap(println, (i = twice, ii = 34, iii = [5, 6], iv = (twice, 34), v = 34
 [1, 2]
 34
 [5, 6]
+34
 34.0
 (i = nothing, ii = nothing, iii = nothing, iv = (nothing, nothing), v = nothing)
 ```
 
-If the same node (same according to `===`) appears more than once,
-it will only be handled once, and only be transformed once with `f`.
-Thus the result will also have this relationship.
+If the same object appears more than once, it will only be handled once, and only be 
+transformed once with `f`. Thus the result will also have this relationship.
+Here "same" means `===` for non-`isbits` types. The same number (e.g. `34 === 34`) at
+different nodes is taken to be a coincidence, and `f` applies twice.
 
 By default, `Tuple`s, `NamedTuple`s, and some other container-like types in Base have
 children to recurse into. Arrays of numbers do not.

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -53,7 +53,7 @@ usecache(::Nothing, x) = false
   fs = fieldnames(T)
   isempty(fs) && return false
   subs =  [:(anymutable(getfield(x, $f))) for f in QuoteNode.(fs)]
-  return :(|($(subs...)))
+  return :(|($(subs...))::Bool)
 end
 
 struct NoKeyword end

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -143,13 +143,7 @@ end
 ###
 
 if VERSION < v"1.7"
-  # # Copied verbatim from Base, except omitting the macro:
-  # function ismutabletype(@nospecialize t)
-  #     # @_total_meta
-  #     t = Base.unwrap_unionall(t)
-  #     return isa(t, DataType) && t.name.flags & 0x2 == 0x2
-  # end
-  
-  # That doesn't work, but this does:
+  # Function in 1.7 checks t.name.flags & 0x2 == 0x2,
+  # but for 1.6 this seems to work instead:
   ismutabletype(@nospecialize t) = t.mutable
 end

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -39,11 +39,15 @@ function _default_walk(f, x)
   re(map(f, func))
 end
 
+usecache(x) = !isbits(x)
+
 struct NoKeyword end
 
-function fmap(f, x; exclude = isleaf, walk = _default_walk, cache = IdDict(), prune = NoKeyword())
-  haskey(cache, x) && return prune isa NoKeyword ? cache[x] : prune
-  cache[x] = exclude(x) ? f(x) : walk(x -> fmap(f, x; exclude=exclude, walk=walk, cache=cache, prune=prune), x)
+function fmap(f, x; exclude = isleaf, walk = _default_walk, cache = usecache(x) ? IdDict() : nothing, prune = NoKeyword())
+  usecache(x) && haskey(cache, x) && return prune isa NoKeyword ? cache[x] : prune
+  xnew = exclude(x) ? f(x) : walk(x -> fmap(f, x; exclude=exclude, walk=walk, cache=cache, prune=prune), x)
+  usecache(x) && setindex!(cache, xnew, x)
+  return xnew
 end
 
 ###
@@ -70,8 +74,10 @@ end
 ###
 
 function fmap(f, x, ys...; exclude = isleaf, walk = _default_walk, cache = IdDict(), prune = NoKeyword())
-  haskey(cache, x) && return prune isa NoKeyword ? cache[x] : prune
-  cache[x] = exclude(x) ? f(x, ys...) : walk((xy...,) -> fmap(f, xy...; exclude=exclude, walk=walk, cache=cache, prune=prune), x, ys...)
+  usecache(x) && haskey(cache, x) && return prune isa NoKeyword ? cache[x] : prune
+  xnew = exclude(x) ? f(x, ys...) : walk((xy...,) -> fmap(f, xy...; exclude=exclude, walk=walk, cache=cache, prune=prune), x, ys...)
+  usecache(x) && setindex!(cache, xnew, x)
+  return xnew
 end
 
 function _default_walk(f, x, ys...)

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -151,10 +151,13 @@ end
 ###
 
 if VERSION < v"1.7"
-  # Copied verbatim from Base, except omitting the macro:
-  function ismutabletype(@nospecialize t)
-      # @_total_meta  
-      t = unwrap_unionall(t)
-      return isa(t, DataType) && t.name.flags & 0x2 == 0x2
-  end
+  # # Copied verbatim from Base, except omitting the macro:
+  # function ismutabletype(@nospecialize t)
+  #     # @_total_meta
+  #     t = Base.unwrap_unionall(t)
+  #     return isa(t, DataType) && t.name.flags & 0x2 == 0x2
+  # end
+  
+  # That doesn't work, but this does:
+  ismutabletype(@nospecialize t) = t.mutable
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -14,6 +14,7 @@ struct NoChildren2; x; y; end
 
 struct NoChild{T}; x::T; end
 
+
 ###
 ### Basic functionality
 ###
@@ -56,13 +57,13 @@ end
   m1p = fmapstructure(identity, m1; prune = nothing)
   @test m1p == (x = [1, 2, 3], y = (x = [1, 2, 3], y = (x = nothing, y = [1, 2, 3])))
 
-  # A non-leaf node can also be repeated:
+  # The cache applies only to leaf nodes, so that "4" is not shared:
   m2 = Foo(Foo(shared, 4), Foo(shared, 4))
   @test m2.x === m2.y
   m2f = fmap(float, m2)
   @test m2f.x.x === m2f.y.x
   m2p = fmapstructure(identity, m2; prune = Bar(0))
-  @test m2p == (x = (x = [1, 2, 3], y = 4), y = Bar(0))
+  @test m2p == (x = (x = [1, 2, 3], y = 4), y = (x = Bar{Int64}(0), y = 4))
 
   # Repeated isbits types should not automatically be regarded as shared:
   m3 = Foo(Foo(shared, 1:3), Foo(1:3, shared))
@@ -75,15 +76,18 @@ end
   @test_skip 0 == @allocated fmap(float, (x=1, y=(2, 3), z=4:5))
 
   @testset "usecache" begin
+    # Leaf types:
     @test usecache([1,2])
-    @test usecache(Ref(3))
-
     @test !usecache(4.0)
+    @test usecache(NoChild([1,2]))
+    @test !usecache(NoChild((3,4)))
+
+    # Not leaf by default, but `exclude` can change that:
+    @test usecache(Ref(3))
     @test !usecache((5, 6.0))
     @test !usecache((a = 2pi, b = missing))
 
-    @test usecache(Bar([1,2]))
-    @test !usecache(Bar((3,4)))
+    @test usecache((x = [1,2,3], y = 4))
   end
 end
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -48,7 +48,7 @@ end
   @test (model′.x, model′.y, model′.z) == (1, 4, 3)
 end
 
-@testset "cache" begin
+@testset "Sharing" begin
   shared = [1,2,3]
   m1 = Foo(shared, Foo([1,2,3], Foo(shared, [1,2,3])))
   m1f = fmap(float, m1)
@@ -56,8 +56,10 @@ end
   @test m1f.x !== m1f.y.x
   m1p = fmapstructure(identity, m1; prune = nothing)
   @test m1p == (x = [1, 2, 3], y = (x = [1, 2, 3], y = (x = nothing, y = [1, 2, 3])))
+  m1no = fmap(float, m1; cache = nothing)  # disable the cache by hand
+  @test m1no.x !== m1no.y.y.x
 
-  # The cache applies only to leaf nodes, so that "4" is not shared:
+  # Here "4" is not shared, because Foo isn't leaf:
   m2 = Foo(Foo(shared, 4), Foo(shared, 4))
   @test m2.x === m2.y
   m2f = fmap(float, m2)
@@ -72,22 +74,39 @@ end
   @test m3p.y.x == 1:3
 
   # All-isbits trees need not create a cache at all:
-  @test isbits(fmap(float, (x=1, y=(2, 3), z=4:5)))
-  @test_skip 0 == @allocated fmap(float, (x=1, y=(2, 3), z=4:5))
+  m4 = (x=1, y=(2, 3), z=4:5)
+  @test isbits(fmap(float, m4))
+  @test_skip 0 == @allocated fmap(float, m4)  # true, but fails in tests
+  
+  # Shared mutable containers are preserved, even if all children are isbits:
+  ref = Ref(1)
+  m5 = (x = ref, y = ref, z = Ref(1))
+  m5f = fmap(x -> x/2, m5)
+  @test m5f.x === m5f.y
+  @test m5f.x !== m5f.z
 
   @testset "usecache" begin
+    d = IdDict()
+
     # Leaf types:
-    @test usecache([1,2])
-    @test !usecache(4.0)
-    @test usecache(NoChild([1,2]))
-    @test !usecache(NoChild((3,4)))
+    @test usecache(d, [1,2])
+    @test !usecache(d, 4.0)
+    @test usecache(d, NoChild([1,2]))
+    @test !usecache(d, NoChild((3,4)))
 
-    # Not leaf by default, but `exclude` can change that:
-    @test usecache(Ref(3))
-    @test !usecache((5, 6.0))
-    @test !usecache((a = 2pi, b = missing))
+    # Not leaf:
+    @test usecache(d, Ref(3))  # mutable container
+    @test !usecache(d, (5, 6.0))
+    @test !usecache(d, (a = 2pi, b = missing))
 
-    @test usecache((x = [1,2,3], y = 4))
+    @test !usecache(d, (5, [6.0]'))  # contains mutable
+    @test !usecache(d, (x = [1,2,3], y = 4))
+    
+    usecache(d, OneChild3([1,2], 3, nothing))  # mutable isn't a child, do we care?
+    
+    # No dictionary:
+    @test !usecache(nothing, [1,2])
+    @test !usecache(nothing, 3)
   end
 end
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -1,5 +1,5 @@
 
-using Functors: functor
+using Functors: functor, usecache
 
 struct Foo; x; y; end
 @functor Foo
@@ -68,7 +68,23 @@ end
   m3 = Foo(Foo(shared, 1:3), Foo(1:3, shared))
   m3p = fmapstructure(identity, m3; prune = 0)
   @test m3p.y.y == 0
-  @test_broken m3p.y.x == 1:3
+  @test m3p.y.x == 1:3
+
+  # All-isbits trees need not create a cache at all:
+  @test isbits(fmap(float, (x=1, y=(2, 3), z=4:5)))
+  @test_skip 0 == @allocated fmap(float, (x=1, y=(2, 3), z=4:5))
+
+  @testset "usecache" begin
+    @test usecache([1,2])
+    @test usecache(Ref(3))
+
+    @test !usecache(4.0)
+    @test !usecache((5, 6.0))
+    @test !usecache((a = 2pi, b = missing))
+
+    @test usecache(Bar([1,2]))
+    @test !usecache(Bar((3,4)))
+  end
 end
 
 @testset "functor(typeof(x), y) from @functor" begin


### PR DESCRIPTION
One of the things #32 proposes is to disable the use of the cache for some types, so that e.g. the number `4` appearing at two nodes is not regarded as a form of parameter sharing, just a co-incidence. This PR wants to make that change alone. 

But what exactly is the right rule here? If `(x = [1,2,3], y = 4)` appears twice, then the shared `[1,2,3]` should be cached, but I think the `4` should still not be. 
```
m1 = (a = (x = [1,2,3], y = 4), b = (x = [1,2,3], y = 4))
m1.a.x !== m1.b.x  # distinct arrays, hence not tied
m1.a.y === m1.b.y  # these are isbits, should not be tied

shared = [1,2,3]
m2 = (a = (x = shared, y = 4), b = (x = shared, y = 4))
m2.a.x === m2.b.x  # these really are tied
m2.a === m2.b  # but these should not be, since they would tie 4 === 4

m3 = (a = [[1,2,3], 4], b = [[1,2,3], 4])
m4 = (a = [shared, 4], b = [shared, 4])  # should still not tie 4 === 4
m4.a !== m4.b  # but now the container won't tempt you
```
This PR thinks that the right test is to only use cache on leaf nodes. #32 tested instead `!isbits(x) && ismutable(x)`, which will also work on these examples. Where they differ is on an immutable container enclosing a mutable array:
```
shared = NamedDimsArray([1,2,3], :tri)  # a Functors-unaware array wrapper struct
shared = TiedArray(SA[1,2,3], Ref(0))   # the idea we had for marking StaticArrays as tied
```
Right now this uses the `exclude` keyword not the fixed `isleaf`. I think that makes sense but haven't thought too hard.