### PR TITLE
Fix missing docs and cross-references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 /dev/
 Manifest.toml
+build
+.vscode

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,6 +7,7 @@ makedocs(modules = [Functors],
          sitename = "Functors.jl",
          pages = ["Home" => "index.md",
                   "API" => "api.md"],
+         strict = [:cross_references, :missing_docs],
          format = Documenter.HTML(
              analytics = "UA-36890222-9",
              assets = ["assets/flux.css"],

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,7 +3,7 @@ using Documenter, Functors
 DocMeta.setdocmeta!(Functors, :DocTestSetup, :(using Functors); recursive = true)
 
 makedocs(modules = [Functors],
-         doctest = VERSION == v"1.6",
+         doctest = false,
          sitename = "Functors.jl",
          pages = ["Home" => "index.md",
                   "API" => "api.md"],

--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -24,7 +24,7 @@ usually using the macro [`@functor`](@ref).
 functor
 
 @static if VERSION >= v"1.5"  # var"@functor" doesn't work on 1.0, temporarily disable
-"""
+@doc """
     @functor T
     @functor T (x,)
 

--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -19,7 +19,7 @@ Returns a tuple containing, first, a `NamedTuple` of the children of `x`
 This controls the behaviour of [`fmap`](@ref).
 
 Methods should be added to `functor(::Type{T}, x)` for custom types,
-usually using the macro [@functor](@ref).
+usually using the macro [`@functor`](@ref).
 """
 functor
 
@@ -32,7 +32,7 @@ Adds methods to [`functor`](@ref) allowing recursion into objects of type `T`,
 and reconstruction. Assumes that `T` has a constructor accepting all of its fields,
 which is true unless you have provided an inner constructor which does not.
 
-By default all fields of `T` are considered [children](@ref); 
+By default all fields of `T` are considered [`children`](@ref); 
 this can be restricted be restructed by providing a tuple of field names.
 
 # Examples

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -30,47 +30,6 @@ function functorm(T, fs = nothing)
   :(makefunctor(@__MODULE__, $(esc(T)), $(fs...)))
 end
 
-"""
-    @functor T
-    @functor T (x,)
-
-Adds methods to [`functor`](@ref) allowing recursion into objects of type `T`,
-and reconstruction. Assumes that `T` has a constructor accepting all of its fields,
-which is true unless you have provided an inner constructor which does not.
-
-By default all fields of `T` are considered [`children`](@ref); 
-this can be restricted be restructed by providing a tuple of field names.
-
-# Examples
-```jldoctest
-julia> struct Foo; x; y; end
-
-julia> @functor Foo
-
-julia> Functors.children(Foo(1,2))
-(x = 1, y = 2)
-
-julia> _, re = Functors.functor(Foo(1,2));
-
-julia> re((10, 20))
-Foo(10, 20)
-
-julia> struct TwoThirds a; b; c; end
-
-julia> @functor TwoThirds (a, c)
-
-julia> ch2, re3 = Functors.functor(TwoThirds(10,20,30));
-
-julia> ch2
-(a = 10, c = 30)
-
-julia> re3(("ten", "thirty"))
-TwoThirds("ten", 20, "thirty")
-
-julia> fmap(x -> 10x, TwoThirds(Foo(1,2), Foo(3,4), 56))
-TwoThirds(Foo(10, 20), Foo(3, 4), 560)
-```
-"""
 macro functor(args...)
   functorm(args...)
 end

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -30,6 +30,47 @@ function functorm(T, fs = nothing)
   :(makefunctor(@__MODULE__, $(esc(T)), $(fs...)))
 end
 
+"""
+    @functor T
+    @functor T (x,)
+
+Adds methods to [`functor`](@ref) allowing recursion into objects of type `T`,
+and reconstruction. Assumes that `T` has a constructor accepting all of its fields,
+which is true unless you have provided an inner constructor which does not.
+
+By default all fields of `T` are considered [`children`](@ref); 
+this can be restricted be restructed by providing a tuple of field names.
+
+# Examples
+```jldoctest
+julia> struct Foo; x; y; end
+
+julia> @functor Foo
+
+julia> Functors.children(Foo(1,2))
+(x = 1, y = 2)
+
+julia> _, re = Functors.functor(Foo(1,2));
+
+julia> re((10, 20))
+Foo(10, 20)
+
+julia> struct TwoThirds a; b; c; end
+
+julia> @functor TwoThirds (a, c)
+
+julia> ch2, re3 = Functors.functor(TwoThirds(10,20,30));
+
+julia> ch2
+(a = 10, c = 30)
+
+julia> re3(("ten", "thirty"))
+TwoThirds("ten", 20, "thirty")
+
+julia> fmap(x -> 10x, TwoThirds(Foo(1,2), Foo(3,4), 56))
+TwoThirds(Foo(10, 20), Foo(3, 4), 560)
+```
+"""
 macro functor(args...)
   functorm(args...)
 end


### PR DESCRIPTION
Some minor changes in the documentation. These changes would help us in fixing the broken links and references in `Flux`'s documentation. 

* make the docs of `@functor` render in the manual
* fix cross-references within the docs
* update `.gitignore`

**Note**: The current docstring of `@functor` does not render, probably because of the `var""` keyword. 