### PR TITLE
Change `getproperty` to `getfield`

### DIFF
--- a/src/functor.jl
+++ b/src/functor.jl
@@ -72,3 +72,20 @@ if VERSION < v"1.7"
   # but for 1.6 this seems to work instead:
   ismutabletype(@nospecialize t) = t.mutable
 end
+
+# https://github.com/JuliaLang/julia/pull/39794
+if VERSION < v"1.7.0-DEV.793"
+    struct Returns{V} <: Function
+        value::V
+        Returns{V}(value) where {V} = new{V}(value)
+        Returns(value) = new{Core.Typeof(value)}(value)
+    end
+
+    (obj::Returns)(args...; kw...) = obj.value
+    function Base.show(io::IO, obj::Returns)
+        show(io, typeof(obj))
+        print(io, "(")
+        show(io, obj.value)
+        print(io, ")")
+    end
+end


### PR DESCRIPTION
Closes #46

Is this going to have any surprising consequences?

Note that `@functor` cannot go the other way, and use `getproperty`/ `propertynames` for everything, as that needs an instance not the type. 

(Could add tests but they'd be kind-of contrived, I mean all existing tests check that this runs, new ones would only check against someone editing these lines back to `getproperty`.)