### PR TITLE
functorize Dict

### DIFF
--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -111,8 +111,8 @@ A structure and type preserving `map`.
 
 By default it transforms every leaf node (identified by `exclude`, default [`isleaf`](@ref))
 by applying `f`, and otherwise traverses `x` recursively using [`functor`](@ref).
-Optionally, it may also be associated with obejcts `ys` with the same tree structure.
-In that case, `f` is applied to the corresponding leaff nodes in `x` and `ys`.
+Optionally, it may also be associated with objects `ys` with the same tree structure.
+In that case, `f` is applied to the corresponding leaf nodes in `x` and `ys`.
 
 # Examples
 ```jldoctest

--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -111,6 +111,8 @@ A structure and type preserving `map`.
 
 By default it transforms every leaf node (identified by `exclude`, default [`isleaf`](@ref))
 by applying `f`, and otherwise traverses `x` recursively using [`functor`](@ref).
+Optionally, it may also be associated with obejcts `ys` with the same tree structure.
+In that case, `f` is applied to the corresponding leaff nodes in `x` and `ys`.
 
 # Examples
 ```jldoctest
@@ -143,6 +145,13 @@ julia> fmap(println, (i = twice, ii = 34, iii = [5, 6], iv = (twice, 34), v = 34
 34
 34.0
 (i = nothing, ii = nothing, iii = nothing, iv = (nothing, nothing), v = nothing)
+
+julia> d1 = Dict("x" => [1,2], "y" => 3);
+
+julia> d2 = Dict("x" => [4,5], "y" => 6);
+
+julia> fmap(+, d1, d2) == Dict("x" => [5, 7], "y" => 9)
+true
 ```
 
 Mutable objects which appear more than once are only handled once (by caching `f(x)` in an `IdDict`).

--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -148,9 +148,9 @@ julia> fmap(println, (i = twice, ii = 34, iii = [5, 6], iv = (twice, 34), v = 34
 
 julia> d1 = Dict("x" => [1,2], "y" => 3);
 
-julia> d2 = Dict("x" => [4,5], "y" => 6);
+julia> d2 = Dict("x" => [4,5], "y" => 6, "z" => "an_extra_value");
 
-julia> fmap(+, d1, d2) == Dict("x" => [5, 7], "y" => 9)
+julia> fmap(+, d1, d2) == Dict("x" => [5, 7], "y" => 9) # Note that "z" is ignored
 true
 ```
 

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -4,6 +4,8 @@ functor(x) = functor(typeof(x), x)
 
 functor(::Type{<:Tuple}, x) = x, identity
 functor(::Type{<:NamedTuple{L}}, x) where L = NamedTuple{L}(map(s -> getproperty(x, s), L)), identity
+functor(::Type{<:Dict}, x) = Dict(k => x[k] for k in keys(x)), identity
+# functor(::Type{<:Dict}, x) = values(x), y -> Dict(zip(keys(x), y)) # alternative not dumping the keys in the children
 
 functor(::Type{<:AbstractArray}, x) = x, identity
 functor(::Type{<:AbstractArray{<:Number}}, x) = (), _ -> x

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -5,7 +5,6 @@ functor(x) = functor(typeof(x), x)
 functor(::Type{<:Tuple}, x) = x, identity
 functor(::Type{<:NamedTuple{L}}, x) where L = NamedTuple{L}(map(s -> getproperty(x, s), L)), identity
 functor(::Type{<:Dict}, x) = Dict(k => x[k] for k in keys(x)), identity
-# functor(::Type{<:Dict}, x) = values(x), y -> Dict(zip(keys(x), y)) # alternative not dumping the keys in the children
 
 functor(::Type{<:AbstractArray}, x) = x, identity
 functor(::Type{<:AbstractArray{<:Number}}, x) = (), _ -> x

--- a/src/walks.jl
+++ b/src/walks.jl
@@ -1,3 +1,7 @@
+_map(f, x...) = map(f, x...)
+_map(f, x::Dict) = Dict(k => f(v) for (k, v) in x)
+
+
 """
     AbstractWalk
 
@@ -53,7 +57,7 @@ struct DefaultWalk <: AbstractWalk end
 function (::DefaultWalk)(recurse, x, ys...)
   func, re = functor(x)
   yfuncs = map(y -> functor(typeof(x), y)[1], ys)
-  re(map(recurse, func, yfuncs...))
+  re(_map(recurse, func, yfuncs...))
 end
 
 """
@@ -66,7 +70,7 @@ See [`fmapstructure`](@ref) for more information.
 """
 struct StructuralWalk <: AbstractWalk end
 
-(::StructuralWalk)(recurse, x) = map(recurse, children(x))
+(::StructuralWalk)(recurse, x) = _map(recurse, children(x))
 
 """
     ExcludeWalk(walk, fn, exclude)
@@ -156,7 +160,7 @@ function (walk::CollectWalk)(recurse, x)
   # to exclude, we wrap this walk in ExcludeWalk
   usecache(walk.cache, x) && push!(walk.cache, x)
   push!(walk.output, x)
-  map(recurse, children(x))
+  _map(recurse, children(x))
 
   return walk.output
 end

--- a/src/walks.jl
+++ b/src/walks.jl
@@ -1,6 +1,8 @@
 _map(f, x...) = map(f, x...)
-_map(f, x::Dict) = Dict(k => f(v) for (k, v) in x)
+_map(f, x::Dict, ys...) = Dict(k => f(v, (y[k] for y in ys)...) for (k, v) in x)
 
+_values(x) = x
+_values(x::Dict) = values(x)
 
 """
     AbstractWalk
@@ -26,7 +28,7 @@ abstract type AbstractWalk end
     AnonymousWalk(walk_fn)
 
 Wrap a `walk_fn` so that `AnonymousWalk(walk_fn) isa AbstractWalk`.
-This type only exists for backwards compatability and should be directly used.
+This type only exists for backwards compatability and should not be directly used.
 Attempting to wrap an existing `AbstractWalk` is a no-op (i.e. it is not wrapped).
 """
 struct AnonymousWalk{F} <: AbstractWalk

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -331,11 +331,9 @@ end
   d = Dict(:a => 1, :b => 2)
   
   @test Functors.children(d) == d
-  # @test collect(Functors.children(d)) == [1, 2]
   @test fmap(x -> x + 1, d) == Dict(:a => 2, :b => 3)
 
   d = Dict(:a => 1, :b => Dict("a" => 5, "b" => 6, "c" => 7))  
   @test Functors.children(d) == d
-  # @test collect(Functors.children(d)) == [1, 2]
   @test fmap(x -> x + 1, d) == Dict(:a => 2, :b => Dict("a" => 6, "b" => 7, "c" => 8))
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -326,3 +326,16 @@ end
   m4 = FBar(m3, (:x,))
   @test all(fcollect(m4) .=== [m4, m3, m2, m0])
 end
+
+@testset "Dict" begin
+  d = Dict(:a => 1, :b => 2)
+  
+  @test Functors.children(d) == d
+  # @test collect(Functors.children(d)) == [1, 2]
+  @test fmap(x -> x + 1, d) == Dict(:a => 2, :b => 3)
+
+  d = Dict(:a => 1, :b => Dict("a" => 5, "b" => 6, "c" => 7))  
+  @test Functors.children(d) == d
+  # @test collect(Functors.children(d)) == [1, 2]
+  @test fmap(x -> x + 1, d) == Dict(:a => 2, :b => Dict("a" => 6, "b" => 7, "c" => 8))
+end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -336,4 +336,14 @@ end
   d = Dict(:a => 1, :b => Dict("a" => 5, "b" => 6, "c" => 7))  
   @test Functors.children(d) == d
   @test fmap(x -> x + 1, d) == Dict(:a => 2, :b => Dict("a" => 6, "b" => 7, "c" => 8))
+
+  @testset "fmap(+, x, y)" begin
+    m1 = Dict("x" => [1,2], "y" => 3)
+    n1 = Dict("x" => [4,5], "y" => 6)
+    @test fmap(+, m1, n1) == Dict("x" => [5, 7], "y" => 9)
+    
+    m1 = Dict(:x => [1,2], :y => 3)
+    n1 = (x = [4,5], y = 6)
+    @test fmap(+, m1, n1) == Dict(:x => [5, 7], :y => 9)
+  end
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -345,5 +345,10 @@ end
     m1 = Dict(:x => [1,2], :y => 3)
     n1 = (x = [4,5], y = 6)
     @test fmap(+, m1, n1) == Dict(:x => [5, 7], :y => 9)
+
+    # extra keys in m1 are ignored
+    m1 = Dict("x" => [1,2], "y" => Dict(:a => 3, :b => 4))
+    n1 = Dict("x" => [4,5], "y" => Dict(:a => 0.1, :b => 0.2, :c => 5), "z" => Dict(:a => 5))
+    @test fmap(+, m1, n1) == Dict("x" => [5, 7], "y" => Dict(:a=>3.1, :b=>4.2))
   end
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -346,7 +346,7 @@ end
     n1 = (x = [4,5], y = 6)
     @test fmap(+, m1, n1) == Dict(:x => [5, 7], :y => 9)
 
-    # extra keys in m1 are ignored
+    # extra keys in n1 are ignored
     m1 = Dict("x" => [1,2], "y" => Dict(:a => 3, :b => 4))
     n1 = Dict("x" => [4,5], "y" => Dict(:a => 0.1, :b => 0.2, :c => 5), "z" => Dict(:a => 5))
     @test fmap(+, m1, n1) == Dict("x" => [5, 7], "y" => Dict(:a=>3.1, :b=>4.2))


### PR DESCRIPTION
With this PR we treat `Dict` similarly to namedtuples: `fmap` involves only the values.
`Base.map` shied away from taking a stance on how to behave with dictionaries and throws an error, so I had to define an internal `_map` method.

Fix #45 
