### PR TITLE
add `@leaf` macro

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,6 +1,7 @@
 ```@docs
 Functors.fmap
 Functors.@functor
+Functors.@leaf
 ```
 
 ```@docs

--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -282,26 +282,26 @@ julia> struct Bar; x; end
 
 julia> @functor Bar
 
-julia> struct NoChildren; x; y; end
+julia> struct TypeWithNoChildren; x; y; end
 
-julia> m = Foo(Bar([1,2,3]), NoChildren(:a, :b))
-Foo(Bar([1, 2, 3]), NoChildren(:a, :b))
+julia> m = Foo(Bar([1,2,3]), TypeWithNoChildren(:a, :b))
+Foo(Bar([1, 2, 3]), TypeWithNoChildren(:a, :b))
 
 julia> fcollect(m)
 4-element Vector{Any}:
- Foo(Bar([1, 2, 3]), NoChildren(:a, :b))
+ Foo(Bar([1, 2, 3]), TypeWithNoChildren(:a, :b))
  Bar([1, 2, 3])
  [1, 2, 3]
- NoChildren(:a, :b)
+ TypeWithNoChildren(:a, :b)
 
 julia> fcollect(m, exclude = v -> v isa Bar)
 2-element Vector{Any}:
- Foo(Bar([1, 2, 3]), NoChildren(:a, :b))
- NoChildren(:a, :b)
+ Foo(Bar([1, 2, 3]), TypeWithNoChildren(:a, :b))
+ TypeWithNoChildren(:a, :b)
 
 julia> fcollect(m, exclude = v -> Functors.isleaf(v))
 2-element Vector{Any}:
- Foo(Bar([1, 2, 3]), NoChildren(:a, :b))
+ Foo(Bar([1, 2, 3]), TypeWithNoChildren(:a, :b))
  Bar([1, 2, 3])
 ```
 """

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -1,5 +1,18 @@
+function functor end
 
-@leaf Any
+const NoChildren = Tuple{}
+
+function makeleaf(m::Module, T)
+  @eval m begin
+    $Functors.functor(::Type{<:$T}, x) = $Functors.NoChildren(), _ -> x
+  end
+end
+
+macro leaf(T)
+  :(makeleaf(@__MODULE__, $(esc(T))))
+end
+
+@leaf Any # every type is a leaf by default
 functor(x) = functor(typeof(x), x)
 
 functor(::Type{<:Tuple}, x) = x, identity
@@ -29,19 +42,6 @@ end
 
 macro functor(args...)
   functorm(args...)
-end
-
-
-const NoChildren = Tuple{}
-
-function makeleaf(m::Module, T)
-  @eval m begin
-    $Functors.functor(::Type{<:$T}, x) = $Functors.NoChildren(), _ -> x
-  end
-end
-
-macro leaf(T)
-  :(makeleaf(@__MODULE__, $(esc(T))))
 end
 
 isleaf(@nospecialize(x)) = children(x) === NoChildren()

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -8,6 +8,11 @@ function makeleaf(m::Module, T)
   end
 end
 
+"""
+    @leaf T
+
+Define [`functor`](@ref) for the type `T` so that  `isleaf(x::T) == true`.
+"""
 macro leaf(T)
   :(makeleaf(@__MODULE__, $(esc(T))))
 end

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -2,19 +2,13 @@ function functor end
 
 const NoChildren = Tuple{}
 
-function makeleaf(m::Module, T)
-  @eval m begin
-    $Functors.functor(::Type{<:$T}, x) = $Functors.NoChildren(), _ -> x
-  end
-end
-
 """
     @leaf T
 
 Define [`functor`](@ref) for the type `T` so that  `isleaf(x::T) == true`.
 """
 macro leaf(T)
-  :(makeleaf(@__MODULE__, $(esc(T))))
+  :($Functors.functor(::Type{<:$(esc(T))}, x) = ($Functors.NoChildren(), _ -> x))
 end
 
 @leaf Any # every type is a leaf by default

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -358,7 +358,7 @@ end
   @functor A
   a = A(1)
   @test Functors.children(a) === (x = 1,)
-  @leaf A
+  Functors.@leaf A
   children, re = Functors.functor(a)
   @test children == Functors.NoChildren() 
   @test re(children) === a

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -24,7 +24,7 @@ struct NoChild{T}; x::T; end
   has_children = Foo(1, 2)
   @test Functors.isleaf(no_children)
   @test !Functors.isleaf(has_children)
-  @test Functors.children(no_children) == ()
+  @test Functors.children(no_children) === Functors.NoChildren()
   @test Functors.children(has_children) == (x=1, y=2)
 end
 
@@ -351,4 +351,15 @@ end
     n1 = Dict("x" => [4,5], "y" => Dict(:a => 0.1, :b => 0.2, :c => 5), "z" => Dict(:a => 5))
     @test fmap(+, m1, n1) == Dict("x" => [5, 7], "y" => Dict(:a=>3.1, :b=>4.2))
   end
+end
+
+@testset "@leaf" begin
+  struct A; x; end
+  @functor A
+  a = A(1)
+  @test Functors.children(a) === (x = 1,)
+  @leaf A
+  children, re = Functors.functor(a)
+  @test children == Functors.NoChildren() 
+  @test re(children) === a
 end


### PR DESCRIPTION
and use the alias `NoChildren` for `Tuple{}`.
No breaking change and no great utility at the moment either, but `@leaf` will be useful when/if the functor structure will be opt-out (#51).