### PR TITLE
One-argument `fmapstructure(x)`

### DIFF
--- a/src/maps.jl
+++ b/src/maps.jl
@@ -12,6 +12,7 @@ function fmap(f, x, ys...; exclude = isleaf,
 end
 
 fmapstructure(f, x; kwargs...) = fmap(f, x; walk = StructuralWalk(), kwargs...)
+fmapstructure(x; kwargs...) = fmapstructure(identity, x; kwargs...)
 
 fcollect(x; exclude = v -> false) =
   fmap(ExcludeWalk(CollectWalk(), _ -> nothing, exclude), _ -> nothing, x)


### PR DESCRIPTION
Maybe this should be called `fstructure(x)` since there's no `map`. The point is to strip all the types for saving etc. Apparently others believe this method should exist:  https://discourse.julialang.org/t/how-to-load-bson-file-of-the-model-build-with-flux-0-12-10-to-use-with-flux-0-13-flux-diagonal-deprecated-problem/91588/2

### PR Checklist

- [ ] Tests are added
- [ ] Documentation, if applicable
