### PR TITLE
Fix recursion performance

### DIFF
--- a/src/maps.jl
+++ b/src/maps.jl
@@ -1,4 +1,12 @@
-fmap(walk::AbstractWalk, f, x, ys...) = walk((xs...) -> fmap(walk, f, xs...), x, ys...)
+function fmap(walk::AbstractWalk, f, x, ys...)
+  #=
+  The below construct avoids a performance penalty
+  for recursive constructs in an anonymous function.
+  See Julia issue #47760 and Functors.jl issue #59.
+  =#
+  recurse(xs...) = walk(var"#self#", xs...)
+  walk(recurse, x, ys...)
+end
 
 function fmap(f, x, ys...; exclude = isleaf,
                            walk = DefaultWalk(),

--- a/src/maps.jl
+++ b/src/maps.jl
@@ -1,17 +1,8 @@
-#=
-Note that the argument f is not actually used in 
-the below version of fmap, which takes a user-specified
-walk. Since this function is public API, the f argument
-has been left in the signature until a (likely breaking)
-decision can be made in the future about how to clean up
-this API (issue #62).
-=#
+# Note that the argument f is not actually used in this method.
+# See issue #62 for a discussion on how best to remove it.
 function fmap(walk::AbstractWalk, f, x, ys...)
-  #=
-  The below construct avoids a performance penalty
-  for recursive constructs in an anonymous function.
-  See Julia issue #47760 and Functors.jl issue #59.
-  =#
+  # This avoids a performance penalty for recursive constructs in an anonymous function.
+  # See Julia issue #47760 and Functors.jl issue #59.
   recurse(xs...) = walk(var"#self#", xs...)
   walk(recurse, x, ys...)
 end

--- a/src/maps.jl
+++ b/src/maps.jl
@@ -4,7 +4,7 @@ the below version of fmap, which takes a user-specified
 walk. Since this function is public API, the f argument
 has been left in the signature until a (likely breaking)
 decision can be made in the future about how to clean up
-this API.
+this API (issue #62).
 =#
 function fmap(walk::AbstractWalk, f, x, ys...)
   #=

--- a/src/maps.jl
+++ b/src/maps.jl
@@ -1,3 +1,11 @@
+#=
+Note that the argument f is not actually used in 
+the below version of fmap, which takes a user-specified
+walk. Since this function is public API, the f argument
+has been left in the signature until a (likely breaking)
+decision can be made in the future about how to clean up
+this API.
+=#
 function fmap(walk::AbstractWalk, f, x, ys...)
   #=
   The below construct avoids a performance penalty


### PR DESCRIPTION
This PR simplifies the recursive structure of walking a functor. It uses a trick from https://github.com/JuliaLang/julia/issues/47760 to resolve https://github.com/FluxML/Functors.jl/issues/59. 

The functionality of `fmap` after this PR is identical to its previous one. Thus, this PR lays bare the fact that the argument `f` is ultimately useless for the version of `fmap` that takes a user-specified walk. Note that this was public API, however, so I kept it in the signature and added an explanatory note.

Obviously the `fmap` API is highly imperfect, but I think this PR is a strict improvement, that simply lays bare some of the issues. (Ultimately, I think that the use of `fmap` with a user-specified arbitrary walk should probably be deprecated: walks are just way too flexible to allow arbitrary walks to be paired with `fmap`. The semantics of `fmap` seem to match best with the specific use case of `ExcludeWalk`: `ExcludeWalk` is what actually uses `f`, after all. The general function allowing for arbitrary walks should probably be called `recursivewalk` or something. But that would be very breaking.)