### PR TITLE
Adjustments to walk recursion

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Functors"
 uuid = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
 authors = ["Mike J Innes <mike.j.innes@gmail.com>"]
-version = "0.4.2"
+version = "0.5.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -105,7 +105,6 @@ children
 
 """
     fmap(f, x, ys...; exclude = Functors.isleaf, walk = Functors.DefaultWalk()[, prune])
-    fmap(walk, f, x, ys...)
 
 A structure and type preserving `map`.
 
@@ -202,9 +201,6 @@ julia> (::MyWalk)(recurse, x) = x isa Bar ? "hello" :
 
 julia> fmap(x -> 10x, m; walk = MyWalk())
 Foo("hello", (40, 50, "hello"))
-
-julia> fmap(MyWalk(), x -> 10x, m)
-Foo("hello", (4, 5, "hello"))
 ```
 
 The behaviour when the same node appears twice can be altered by giving a value

--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -188,16 +188,16 @@ To recurse into custom types without reconstructing them afterwards,
 use [`fmapstructure`](@ref).
 
 For advanced customization of the traversal behaviour,
-pass a custom `walk` function that subtypes [`Functors.AbstractWalk`](ref).
-The form `fmap(walk, f, x, ys...)` can be called for custom walks.
-The simpler form `fmap(f, x, ys...; walk = mywalk)` will wrap `mywalk` in
+pass a custom `mywalk` that subtypes [`Functors.AbstractWalk`](ref).
+An application of `fmap(f, x, ys...; walk = mywalk)` will wrap `mywalk` in
 [`ExcludeWalk`](@ref) then [`CachedWalk`](@ref).
 
 ```jldoctest withfoo
 julia> struct MyWalk <: Functors.AbstractWalk end
 
-julia> (::MyWalk)(recurse, x) = x isa Bar ? "hello" :
-                                            Functors.DefaultWalk()(recurse, x)
+julia> function (::MyWalk)(outer_walk::Functors.AbstractWalk, x)
+            x isa Bar ? "hello" : Functors.DefaultWalk()(outer_walk, x)
+       end
 
 julia> fmap(x -> 10x, m; walk = MyWalk())
 Foo("hello", (40, 50, "hello"))

--- a/src/maps.jl
+++ b/src/maps.jl
@@ -1,11 +1,4 @@
-# Note that the argument f is not actually used in this method.
-# See issue #62 for a discussion on how best to remove it.
-function fmap(walk::AbstractWalk, f, x, ys...)
-  # This avoids a performance penalty for recursive constructs in an anonymous function.
-  # See Julia issue #47760 and Functors.jl issue #59.
-  recurse(xs...) = walk(var"#self#", xs...)
-  walk(recurse, x, ys...)
-end
+Base.@deprecate fmap(walk::AbstractWalk, f, x, ys...) walk(x, ys...)
 
 function fmap(f, x, ys...; exclude = isleaf,
                            walk = DefaultWalk(),
@@ -15,10 +8,12 @@ function fmap(f, x, ys...; exclude = isleaf,
   if !isnothing(cache)
     _walk = CachedWalk(_walk, prune, cache)
   end
-  fmap(_walk, f, x, ys...)
+  _walk(x, ys...)
 end
 
 fmapstructure(f, x; kwargs...) = fmap(f, x; walk = StructuralWalk(), kwargs...)
 
-fcollect(x; exclude = v -> false) =
-  fmap(ExcludeWalk(CollectWalk(), _ -> nothing, exclude), _ -> nothing, x)
+function fcollect(x; exclude = v -> false)
+  walk = ExcludeWalk(CollectWalk(), _ -> nothing, exclude)
+  walk(x)
+end

--- a/src/walks.jl
+++ b/src/walks.jl
@@ -10,9 +10,9 @@ _values(x::Dict) = values(x)
 Any walk for use with [`fmap`](@ref) should inherit from this type.
 A walk subtyping `AbstractWalk` must satisfy the walk function interface:
 ```julia
-struct MyWalk <: AbstractWalk end
+struct MyWalk <: Functors.AbstractWalk end
 
-function (::MyWalk)(outer_walk::AbstractWalk, x, ys...)
+function (::MyWalk)(outer_walk::Functors.AbstractWalk, x, ys...)
   # implement this
 end
 ```

--- a/src/walks.jl
+++ b/src/walks.jl
@@ -23,7 +23,9 @@ The walk function recurses further into `(x, ys...)` by calling
 The choice of which nodes to recurse and in what order is custom to the walk.
 By default, `outer_walk` it set to the walk being called,
 i.e. `(walk::AbstractWalk)(x, ys...) = walk(walk, x, ys...)`,
-but in general it allows for greater flexibility (e.g. nesting walks in one another).
+but in general it allows for greater flexibility when nesting walks in one another.
+!!! warning "Don't forget the type annotation!"
+    When defining your own custom walk, the type annotation of `Functors.AbstractWalk` on `outer_walk` is necessary for correct dispatch.
 """
 abstract type AbstractWalk end
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -378,3 +378,7 @@ end
     @test zipped_iter isa Iterators.Flatten
     @test collect(zipped_iter) == collect(Iterators.zip([1, 2, 3, 4, 5, 6, 7, 8].^2, [8, 7, 6, 5, 4, 3, 2, 1].^2))
 end
+
+@testset "Deprecated first-arg walk API to fmap" begin
+  @test fmap(Functors.DefaultWalk(), nothing, (1, 2, 3)) == (1, 2, 3)
+end


### PR DESCRIPTION
Adjusts the `walk::AbstractWalk` interface to naturally support recursion through `walk(x, ys...)` and deprecates an old `fmap` signature; resolves #62.

One subtle point: I wanted to leave the `recurse` first-arg exactly as is which would have made the diff even smaller. However, for the dispatch to work, we needed to restrict the first arg `recurse` to be an `AbstractWalk` when implementing walk subtypes, in which case it made more sense to call it `outer_walk`, or something of that nature. [This is a breaking change for people who have defined custom walks, since custom subtypes of walk will need to make sure to have this dispatch. This leads to IMO the cleanest API, but I could use something more clunky than `walk(x, ys...)` for the recursive walk and avoid the breaking change if desired. The main point of this PR is to show that something like the  `recurse` closure is not necessary]