### PR TITLE
Add support for Base.Broadcast.BroadcastFunction

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -5,8 +5,7 @@
 
 @functor Base.Generator  # aka Iterators.map
 
-functor(::Type{<:Base.ComposedFunction}, x) = (outer = x.outer, inner = x.inner), y -> Base.ComposedFunction(y.outer, y.inner)
-
+@functor Base.ComposedFunction
 @functor Base.Fix1
 @functor Base.Fix2
 @functor Base.Broadcast.BroadcastFunction

--- a/src/base.jl
+++ b/src/base.jl
@@ -9,6 +9,7 @@ functor(::Type{<:Base.ComposedFunction}, x) = (outer = x.outer, inner = x.inner)
 
 @functor Base.Fix1
 @functor Base.Fix2
+@functor Base.Broadcast.BroadcastFunction
 
 ###
 ### Array wrappers

--- a/test/base.jl
+++ b/test/base.jl
@@ -42,6 +42,14 @@ end
     @test fmap(sqrt, Base.Fix2(/, 4); exclude)(10) == 5.0
 end
 
+@testset "BroadcastFunction" begin
+  f = Bar(3.3)
+  bf = Base.Broadcast.BroadcastFunction(f)
+  @test Functors.functor(bf)[1] == (f = f,)
+  @test Functors.functor(bf)[2]((f = f,)) == bf
+  @test fmap(x -> x + 10, bf) == Base.Broadcast.BroadcastFunction(Bar(13.3))
+end
+
 @testset "LinearAlgebra containers" begin
   @test fmapstructure(identity, [1,2,3]') == (parent = [1, 2, 3],)
   @test fmapstructure(identity, transpose([1,2,3])) == (parent = [1, 2, 3],)


### PR DESCRIPTION
In addition to adding support for `Base.Broadcast.BroadcastFunction` also simplifies handling of `Base.ComposedFunction` by using `@functor`.

With this in place, we can implement a simple NN layer from scratch with only Base functionality. I'm use a "scaled relu" here so that there's some number to update in one of the `BroadcastFunction`s - just a toy example, of course:

```julia
using Base.Broadcast: BroadcastFunction
using Base: Fix1

weights = rand(2, 5)
bias = rand(2)
relu(x) = max(zero(x), x)
scaled_relu = Fix1(*, 0.3) ∘ relu
X = rand(5, 20)

layer = BroadcastFunction(scaled_relu) ∘ Fix1(BroadcastFunction(+), bias) ∘ Fix1(*, weights)

layer(X)

using Functors, Zygote

struct GradientDecent{T}
    rate::T
end
(opt::GradientDecent)(x, ::Nothing) = x
(opt::GradientDecent)(x::Real, dx::Real) = x - opt.rate * dx
(opt::GradientDecent)(x::AbstractArray, dx::AbstractArray) = x .- opt.rate .* dx
function (opt::GradientDecent)(x, dx)
    content_x, re = Functors.functor(x)
    content_dx, _ = Functors.functor(dx)
    re(map(opt, content_x, content_dx))
end

grad = Zygote.gradient((f, x) -> sum(f(x)), layer, X)[1]
updated_layer = GradientDecent(1)(layer, grad)

# Fails without this PR:
# The `0.3` in the "scaled relu" is not updated without functor support in `BroadcastFunction`:
@assert layer.outer.outer.f.outer.x != updated_layer.outer.outer.f.outer.x
```


### PR Checklist

- [x] Tests are added
- [x] Documentation (not applicable here)
