### PR TITLE
Preserve `@functor` property order when reconstructing

### DIFF
--- a/test/basics.jl
+++ b/test/basics.jl
@@ -14,6 +14,9 @@ struct NoChildren2; x; y; end
 
 struct NoChild{T}; x::T; end
 
+struct WrongOrder; x; y; z; end
+@functor WrongOrder (z, x)
+
 
 ###
 ### Basic functionality
@@ -53,8 +56,11 @@ end
 @testset "Property list" begin
   model = OneChild3(1, 2, 3)
   model′ = fmap(x -> 2x, model)
-
   @test (model′.x, model′.y, model′.z) == (1, 4, 3)
+
+  model = WrongOrder(1, 2, 3)
+  model′ = fmap(x -> 2x, model)
+  @test (model′.x, model′.y, model′.z) == (2, 2, 6)
 end
 
 @testset "Sharing" begin


### PR DESCRIPTION
Fixes https://github.com/FluxML/Functors.jl/issues/68.

I originally hoped to have just the NamedTuple overload, but it turns out we're still documenting reconstructing from a plain tuple: https://github.com/FluxML/Functors.jl/blob/v0.4.4/src/Functors.jl#L49-L62.

### PR Checklist

- [x] Tests are added
~~- [ ] Documentation, if applicable~~
