### PR TITLE
Fix anymutable errors with self-referencing types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Functors"
 uuid = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
 authors = ["Mike J Innes <mike.j.innes@gmail.com>"]
-version = "0.4.6"
+version = "0.4.7"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ version = "0.4.6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
-Documenter = "0.27"
+Documenter = "1"
 julia = "1.6"
 
 [extras]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,2 +1,5 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,7 +7,6 @@ makedocs(modules = [Functors],
          sitename = "Functors.jl",
          pages = ["Home" => "index.md",
                   "API" => "api.md"],
-         strict = [:cross_references, :missing_docs],
          format = Documenter.HTML(
              analytics = "UA-36890222-9",
              assets = ["assets/flux.css"],

--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -188,7 +188,7 @@ To recurse into custom types without reconstructing them afterwards,
 use [`fmapstructure`](@ref).
 
 For advanced customization of the traversal behaviour,
-pass a custom `walk` function that subtypes [`Functors.AbstractWalk`](ref).
+pass a custom `walk` function that subtypes [`Functors.AbstractWalk`](@ref).
 The call `fmap(f, x, ys...; walk = mywalk)` will wrap `mywalk` in
 [`ExcludeWalk`](@ref) then [`CachedWalk`](@ref).
 Here, [`ExcludeWalk`](@ref) is responsible for applying `f` at excluded nodes.

--- a/src/walks.jl
+++ b/src/walks.jl
@@ -114,7 +114,8 @@ usecache(::Nothing, x) = false
 
 @generated function anymutable(x::T) where {T}
   ismutabletype(T) && return true
-  subs =  [:(anymutable(getfield(x, $f))) for f in QuoteNode.(fieldnames(T))]
+  fns = QuoteNode.(filter(n -> fieldtype(T, n) != T, fieldnames(T)))
+  subs =  [:(anymutable(getfield(x, $f))) for f in fns]
   return Expr(:(||), subs...)
 end
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -123,6 +123,10 @@ end
   end
 end
 
+@testset "Self-referencing types" begin
+    @test fmap(identity, Base.ImmutableDict(:a => 42)) == Base.ImmutableDict(:a => 42)
+end
+
 @testset "functor(typeof(x), y) from @functor" begin
   nt1, re1 = functor(Foo, (x=1, y=2, z=3))
   @test nt1 == (x = 1, y = 2)


### PR DESCRIPTION
I currently have trouble using `fmap` with data structures that contains `Measurements.Measurement` objects. The reason is that `Measurement` (which subtypes `Real`) contains a field `Derivatives`:

```julia
struct Derivatives{T} <: AbstractDict{Tuple{T,T,UInt64},T}
    parent::Derivatives{T}
    ...
end
```

Due to the nature of the type, this `parent` field may be undefined - quite normal for such datatypes.(`Measurements.Derivatives` is a variation of `Base.ImmutableDict`, apparently).

This causes `Functors.anymutable` to fail, due to

```julia
@generated function anymutable(x::T) where {T}
  ...
  subs =  [:(anymutable(getfield(x, $f))) for f in QuoteNode.(fieldnames(T))]
  ...
end
```

While I have this problem with `Measurement` specifically, I think it makes sense to fix it here, instead of proposing a Functors extension to Measurements. Also, as expected (see above) the same problem occurs with `Base.ImmutableDict`:

```julia
julia> fmap(identity, Base.ImmutableDict(:b => 42))
ERROR: UndefRefError: access to undefined reference
```

A simple fix would be checking with `isdefined` (if the field is not defined, it obviously doesn't point to mutable content):

```julia
@generated function anymutable(x::T) where {T}
  ...
  subs =  [:(isdefined(x, $f) && anymutable(getfield(x, $f))) for f in QuoteNode.(fieldnames(T))]
  ...
end
```

I worry that this may reduce the type stability of `anymutable` though. So in this PR I'm proposing

```julia
@generated function anymutable(x::T) where {T}
  ...
  fns = QuoteNode.(filter(n -> fieldtype(T, n) != T, fieldnames(T)))
  subs =  [:(anymutable(getfield(x, $f))) for f in fns]
  ...
end
```

In the end, mutability is a type property, I'd say:  if `T` itself is not directly mutable, and all of it's fields except references to `T` are immutable, then I think it's safe to consider `x` immutable as a whole.