### PR TITLE
add function `fleaves`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -25,5 +25,5 @@ Functors.IterateWalk
 ```@docs
 Functors.fmapstructure
 Functors.fcollect
-Functors.fflatten
+Functors.fleaves
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -25,4 +25,5 @@ Functors.IterateWalk
 ```@docs
 Functors.fmapstructure
 Functors.fcollect
+Functors.fflatten
 ```

--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -1,6 +1,6 @@
 module Functors
 
-export @functor, @flexiblefunctor, fmap, fmapstructure, fcollect, execute, fflatten
+export @functor, @flexiblefunctor, fmap, fmapstructure, fcollect, execute, fleaves
 
 include("functor.jl")
 include("walks.jl")
@@ -306,7 +306,7 @@ fcollect
 
 
 """
-    fflatten(x; exclude = isleaf)
+    fleaves(x; exclude = isleaf)
 
 Traverse `x` by recursing each child of `x` as defined by [`functor`](@ref)
 and collecting the leaves into a flat array, 
@@ -328,11 +328,11 @@ julia> struct TypeWithNoChildren; x; y; end
 
 julia> m = (a=Bar([1,2,3]), b=TypeWithNoChildren(4, 5))
 
-julia> fflatten(m)
+julia> fleaves(m)
 2-element Vector{Any}:
  [1, 2, 3]
  TypeWithNoChildren(:a, :b)
 """
-fflatten
+fleaves
 
 end # module

--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -309,8 +309,13 @@ fcollect
     fflatten(x; exclude = isleaf)
 
 Traverse `x` by recursing each child of `x` as defined by [`functor`](@ref)
-and collecting the leaves into a flat array, ordered by a breadth-first
-traversal of `x`, respecting the iteration order of `children` calls.
+and collecting the leaves into a flat array, 
+ordered by a breadth-first traversal of `x`, respecting the iteration order of `children` calls.
+
+The `exclude` function is used to determine whether to recurse into a node, therefore
+identifying the leaves as the nodes for which `exclude` returns `true`.
+
+See also [`fcollect`](@ref) for a similar function that collects all nodes instead.
 
 # Examples
 

--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -1,6 +1,6 @@
 module Functors
 
-export @functor, @flexiblefunctor, fmap, fmapstructure, fcollect, execute
+export @functor, @flexiblefunctor, fmap, fmapstructure, fcollect, execute, fflatten
 
 include("functor.jl")
 include("walks.jl")
@@ -302,5 +302,32 @@ julia> fcollect(m, exclude = v -> Functors.isleaf(v))
 ```
 """
 fcollect
+
+
+
+"""
+    fflatten(x; exclude = isleaf)
+
+Traverse `x` by recursing each child of `x` as defined by [`functor`](@ref)
+and collecting the leaves into a flat array, ordered by a breadth-first
+traversal of `x`, respecting the iteration order of `children` calls.
+
+# Examples
+
+```jldoctest
+julia> struct Bar; x; end
+
+julia> @functor Bar
+
+julia> struct TypeWithNoChildren; x; y; end
+
+julia> m = (a=Bar([1,2,3]), b=TypeWithNoChildren(4, 5))
+
+julia> fflatten(m)
+2-element Vector{Any}:
+ [1, 2, 3]
+ TypeWithNoChildren(:a, :b)
+"""
+fflatten
 
 end # module

--- a/src/maps.jl
+++ b/src/maps.jl
@@ -15,3 +15,6 @@ fmapstructure(f, x; kwargs...) = fmap(f, x; walk = StructuralWalk(), kwargs...)
 
 fcollect(x; exclude = v -> false) =
   execute(ExcludeWalk(CollectWalk(), _ -> nothing, exclude), x)
+
+fflatten(x; exclude = isleaf) =
+  execute(ExcludeWalk(FlattenWalk(), x -> [x], exclude), x)

--- a/src/maps.jl
+++ b/src/maps.jl
@@ -16,5 +16,5 @@ fmapstructure(f, x; kwargs...) = fmap(f, x; walk = StructuralWalk(), kwargs...)
 fcollect(x; exclude = v -> false) =
   execute(ExcludeWalk(CollectWalk(), _ -> nothing, exclude), x)
 
-fflatten(x; exclude = isleaf) =
+fleaves(x; exclude = isleaf) =
   execute(ExcludeWalk(FlattenWalk(), x -> [x], exclude), x)

--- a/src/walks.jl
+++ b/src/walks.jl
@@ -234,7 +234,17 @@ julia> collect(zipped_iter)
 struct IterateWalk <: AbstractWalk end
 
 function (walk::IterateWalk)(recurse, x, ys...)
-  func, _ = functor(x)
-  yfuncs = map(y -> functor(typeof(x), y)[1], ys)
-  return Iterators.flatten(_map(recurse, func, yfuncs...))
+  x_children = children(x)
+  ys_children = map(children, ys)
+  return Iterators.flatten(_map(recurse, x_children, ys_children...))
 end
+
+struct FlattenWalk <: AbstractWalk end
+
+function (walk::FlattenWalk)(recurse, x, ys...)
+  x_children = _values(children(x))
+  ys_children = map(children, ys)
+  res = _map(recurse, x_children, ys_children...)
+  return reduce(vcat, _values(res))
+end
+

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -393,13 +393,13 @@ end
   @test (@test_deprecated fmap(Functors.DefaultWalk(), nothing, (1, 2, 3))) == (1, 2, 3)
 end
 
-@testset "fflatten" begin
+@testset "fleaves" begin
   x = (1, (2, 3), (a=4, b=(5, 6), c=7));
-  @test fflatten(x) == [1, 2, 3, 4, 5, 6, 7]
-  @test fflatten(x, exclude=x -> Functors.isleaf(x) || (x isa NamedTuple)) == [1, 2, 3, (a = 4, b = (5, 6), c = 7)]
+  @test fleaves(x) == [1, 2, 3, 4, 5, 6, 7]
+  @test fleaves(x, exclude=x -> Functors.isleaf(x) || (x isa NamedTuple)) == [1, 2, 3, (a = 4, b = (5, 6), c = 7)]
 
   x = Dict("a" => Foo(1, 2), "b" => Bar([1,2,3]))
-  xflat = fflatten(x)
+  xflat = fleaves(x)
   # @test xflat== [1, 2, [1, 2, 3]] # cannot guarantee ordering with Dict
   @test xflat isa Vector
   @test length(xflat) == 3

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -392,3 +392,16 @@ end
 @testset "Deprecated first-arg walk API to fmap" begin
   @test (@test_deprecated fmap(Functors.DefaultWalk(), nothing, (1, 2, 3))) == (1, 2, 3)
 end
+
+@testset "fflatten" begin
+  x = (1, (2, 3), (a=4, b=(5, 6), c=7));
+  @test fflatten(x) == [1, 2, 3, 4, 5, 6, 7]
+  @test fflatten(x, exclude=x -> Functors.isleaf(x) || (x isa NamedTuple)) == [1, 2, 3, (a = 4, b = (5, 6), c = 7)]
+
+  x = Dict("a" => Foo(1, 2), "b" => Bar([1,2,3]))
+  xflat = fflatten(x)
+  # @test xflat== [1, 2, [1, 2, 3]] # cannot guarantee ordering with Dict
+  @test xflat isa Vector
+  @test length(xflat) == 3
+  @test 1 ∈ xflat && 2 ∈ xflat && [1, 2, 3] ∈ xflat
+end


### PR DESCRIPTION
Adds utility function ~fflatten~ `fleaves` that flatten the leaves into an array, similarly to jax's [tree_leaves](https://jax.readthedocs.io/en/latest/_autosummary/jax.tree_util.tree_leaves.html).
Useful for models' parameters collection:
```julia
julia> using Flux

julia> m = Chain(Dense(2=>3, relu), Dense(3 => 2))
Chain(
  Dense(2 => 3, relu),                  # 9 parameters
  Dense(3 => 2),                        # 8 parameters
)                   # Total: 4 arrays, 17 parameters, 324 bytes.

julia> fleaves(m)
6-element Vector{Any}:
 Float32[-0.0102046095 -0.28821245; 0.4982538 0.23464581; -0.70785844 0.3291903]
 Float32[0.0, 0.0, 0.0]
 relu (generic function with 2 methods)
 Float32[0.57762665 -0.8608131 -0.5159058; -0.54350173 0.61605966 0.8265723]
 Float32[0.0, 0.0]
 identity (generic function with 1 method)
```