### PR TITLE
extend `fmapstructure` and add `KeyPath`, `fmap_with_path`, `fmapstructure_with_path`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,5 +1,6 @@
 ```@docs
 Functors.fmap
+Functors.fmap_with_path
 Functors.@functor
 Functors.@leaf
 ```
@@ -24,6 +25,11 @@ Functors.IterateWalk
 
 ```@docs
 Functors.fmapstructure
+Functors.fmapstructure_with_path
 Functors.fcollect
 Functors.fleaves
+```
+
+```@docs
+Functors.KeyPath
 ```

--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -332,9 +332,9 @@ for more information.
 ```jldoctest
 julia> x = ([1, 2, 3], 4, (a=5, b=Dict("A"=>6, "B"=>7), c=Dict("C"=>8, "D"=>9)));
 
-julia> fexclude(kp, x) = kp == KeyPath(3, :c) || Functors.isleaf(x);
+julia> exclude(kp, x) = kp == KeyPath(3, :c) || Functors.isleaf(x);
 
-julia> fmap_with_path((kp, x) -> x isa Dict ? nothing : x.^2, x; exclude = fexclude)
+julia> fmap_with_path((kp, x) -> x isa Dict ? nothing : x.^2, x; exclude = exclude)
 ([1, 4, 9], 16, (a = 25, b = Dict("B" => 49, "A" => 36), c = nothing))
 ```
 """
@@ -373,12 +373,12 @@ julia> @functor Bar
 
 julia> struct TypeWithNoChildren; x; y; end
 
-julia> m = (a=Bar([1,2,3]), b=TypeWithNoChildren(4, 5))
+julia> m = (a = Bar([1,2,3]), b = TypeWithNoChildren(4, 5));
 
 julia> fleaves(m)
 2-element Vector{Any}:
  [1, 2, 3]
- TypeWithNoChildren(:a, :b)
+ TypeWithNoChildren(4, 5)
 ```
 """
 fleaves

--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -1,8 +1,10 @@
 module Functors
 
-export @functor, @flexiblefunctor, fmap, fmapstructure, fcollect, execute, fleaves
+export @functor, @flexiblefunctor, fmap, fmapstructure, fcollect, execute, fleaves, 
+       KeyPath, fmap_with_path, fmapstructure_with_path
 
 include("functor.jl")
+include("keypath.jl")
 include("walks.jl")
 include("maps.jl")
 include("base.jl")
@@ -104,7 +106,7 @@ Equivalent to `functor(x)[1]`.
 children
 
 """
-    fmap(f, x, ys...; exclude = Functors.isleaf, walk = Functors.DefaultWalk()[, prune])
+    fmap(f, x, ys...; exclude = Functors.isleaf, walk = Functors.DefaultWalk(), [prune])
 
 A structure and type preserving `map`.
 
@@ -112,6 +114,8 @@ By default it transforms every leaf node (identified by `exclude`, default [`isl
 by applying `f`, and otherwise traverses `x` recursively using [`functor`](@ref).
 Optionally, it may also be associated with objects `ys` with the same tree structure.
 In that case, `f` is applied to the corresponding leaf nodes in `x` and `ys`.
+
+See also [`fmap_with_path`](@ref) and [`fmapstructure`](@ref).
 
 # Examples
 ```jldoctest
@@ -222,13 +226,15 @@ fmap
 
 
 """
-    fmapstructure(f, x; exclude = isleaf)
+    fmapstructure(f, x, ys...; exclude = isleaf, [prune])
 
 Like [`fmap`](@ref), but doesn't preserve the type of custom structs.
 Instead, it returns a `NamedTuple` (or a `Tuple`, or an array),
 or a nested set of these.
 
 Useful for when the output must not contain custom structs.
+
+See also [`fmap`](@ref) and [`fmapstructure_with_path`](@ref).
 
 # Examples
 ```jldoctest
@@ -304,6 +310,47 @@ julia> fcollect(m, exclude = v -> Functors.isleaf(v))
 fcollect
 
 
+""""
+    fmap_with_path(f, x, ys...; exclude = isleaf, walk = DefaultWalkWithPath(), [prune])
+
+Like [`fmap`](@ref), but also passes a [`KeyPath`](@ref Functors.KeyPath) to `f` for each node in the
+recursion. The `KeyPath` is a tuple of the indices used to reach the current
+node from the root of the recursion. The `KeyPath` is constructed by the
+`walk` function, and can be used to reconstruct the path to the current node
+from the root of the recursion.
+
+`f` has to accept two arguments: the associated `KeyPath` and the value of the current node.
+
+`exclude` also receives the `KeyPath` as its first argument and a node as its second.
+It should return `true` if the recursion should not continue on its children and `f` applied to it.
+
+`prune` is used to control the behaviour when the same node appears twice, see [`fmap`](@ref)
+for more information.
+
+# Examples
+
+```jldoctest
+julia> x = ([1, 2, 3], 4, (a=5, b=Dict("A"=>6, "B"=>7), c=Dict("C"=>8, "D"=>9)));
+
+julia> fexclude(kp, x) = kp == KeyPath(3, :c) || Functors.isleaf(x);
+
+julia> fmap_with_path((kp, x) -> x isa Dict ? nothing : x.^2, x; exclude = fexclude)
+([1, 4, 9], 16, (a = 25, b = Dict("B" => 49, "A" => 36), c = nothing))
+```
+"""
+fmap_with_path
+
+"""
+    fmapstructure_with_path(f, x, ys...; [exclude, prune])
+
+Like [`fmap_with_path`](@ref), but doesn't preserve the type of custom structs.
+Instead, it returns a named tuple, a tuple, an array, a dict, 
+or a nested set of these.
+
+See also [`fmapstructure`](@ref).
+"""
+fmapstructure_with_path
+
 
 """
     fleaves(x; exclude = isleaf)
@@ -332,7 +379,9 @@ julia> fleaves(m)
 2-element Vector{Any}:
  [1, 2, 3]
  TypeWithNoChildren(:a, :b)
+```
 """
 fleaves
 
 end # module
+

--- a/src/keypath.jl
+++ b/src/keypath.jl
@@ -1,0 +1,47 @@
+KeyT = Union{Symbol, AbstractString, Integer}
+
+"""
+    KeyPath(keys...)
+
+A type for representing a path of keys to a value in a nested structure.
+Can be constructed with a sequence of keys, or by concatenating other `KeyPath`s.
+Keys can be of type `Symbol`, `String`, or `Int`.
+
+# Examples
+
+```jldoctest
+julia> kp = KeyPath(:b, 3)
+KeyPath(:b, 3)
+
+julia> KeyPath(:a, kp, :c, 4)
+KeyPath(:a, :b, 3, :c, 4)
+```
+"""
+struct KeyPath{T<:Tuple}
+    keys::T    
+end
+
+@functor KeyPath
+isleaf(::KeyPath, @nospecialize(x)) = isleaf(x)
+
+function KeyPath(keys::Union{KeyT, KeyPath}...)
+    ks = (k isa KeyPath ? (k.keys...,) : (k,) for k in keys)
+    return KeyPath(((ks...)...,))
+end
+
+Base.getindex(kp::KeyPath, i::Int) = kp.keys[i]
+Base.length(kp::KeyPath) = length(kp.keys)
+Base.iterate(kp::KeyPath, state=1) = iterate(kp.keys, state)
+Base.:(==)(kp1::KeyPath, kp2::KeyPath) = kp1.keys == kp2.keys
+
+function Base.show(io::IO, kp::KeyPath)
+    compat = get(io, :compact, false)
+    if compat
+        print(io, keypathstr(kp))          
+    else
+        print(io, "KeyPath$(kp.keys)")
+    end
+end
+
+keypathstr(kp::KeyPath) = join(kp.keys, ".")
+

--- a/src/maps.jl
+++ b/src/maps.jl
@@ -11,7 +11,22 @@ function fmap(f, x, ys...; exclude = isleaf,
   execute(_walk, x, ys...)
 end
 
-fmapstructure(f, x; kwargs...) = fmap(f, x; walk = StructuralWalk(), kwargs...)
+function fmap_with_path(f, x, ys...; 
+                exclude = isleaf,
+                walk = DefaultWalkWithPath(),
+                cache = IdDict(),
+                prune = NoKeyword())
+  
+  _walk = ExcludeWalkWithKeyPath(walk, f, exclude)
+  if !isnothing(cache)
+    _walk = CachedWalkWithPath(_walk, prune, cache)
+  end
+  return execute(_walk, KeyPath(), x, ys...)
+end
+
+fmapstructure(f, x, ys...; kwargs...) = fmap(f, x, ys...; walk = StructuralWalk(), kwargs...)
+
+fmapstructure_with_path(f, x, ys...; kwargs...) = fmap_with_path(f, x, ys...; walk = StructuralWalkWithPath(), kwargs...)
 
 fcollect(x; exclude = v -> false) =
   execute(ExcludeWalk(CollectWalk(), _ -> nothing, exclude), x)

--- a/src/maps.jl
+++ b/src/maps.jl
@@ -11,11 +11,10 @@ function fmap(f, x, ys...; exclude = isleaf,
   execute(_walk, x, ys...)
 end
 
-function fmap_with_path(f, x, ys...; 
-                exclude = isleaf,
-                walk = DefaultWalkWithPath(),
-                cache = IdDict(),
-                prune = NoKeyword())
+function fmap_with_path(f, x, ys...; exclude = isleaf,
+                                     walk = DefaultWalkWithPath(),
+                                     cache = IdDict(),
+                                     prune = NoKeyword())
   
   _walk = ExcludeWalkWithKeyPath(walk, f, exclude)
   if !isnothing(cache)

--- a/test/keypath.jl
+++ b/test/keypath.jl
@@ -1,0 +1,18 @@
+@testset "KeyPath" begin
+    kp = KeyPath(:a, 3, :b, 4)
+    @test (kp...,) === (:a, 3, :b, 4)
+    @test length(kp) == 4
+    @test kp[1] == :a
+    @test kp[2] == 3
+    @test kp[3] == :b
+    @test kp[4] == 4
+
+    kp2 = KeyPath(:a, kp, :c, 5)
+    @test (kp2...,) === (:a, :a, 3, :b, 4, :c, 5)
+
+    kp3 = KeyPath(kp, kp2)
+    @test (kp3...,) === (:a, 3, :b, 4, :a, :a, 3, :b, 4, :c, 5)    
+
+    kp0 = KeyPath()
+    @test (kp0...,) === ()
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using StaticArrays
 
   include("basics.jl")
   include("base.jl")
+  include("keypath.jl")
 
   if VERSION < v"1.6" # || VERSION > v"1.7-"
     @warn "skipping doctests, on Julia $VERSION"


### PR DESCRIPTION
Adding some utilities for working with paths along trees:
- `KeyPath`
- `fmap_with_path`
- `fmapstructure_with_path`
 
Since it came for free, I also extended `fmapstructure` to handle multiple inputs.

In Jax they have KeyPath and [tree_map_with_path](https://jax.readthedocs.io/en/latest/_autosummary/jax.tree_util.tree_map_with_path.html)

TODO
- [x] add tests for `fmap_with_path`
- [x] add to docs