### PR TITLE
add `getkeypath`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,5 +1,6 @@
 ```@docs
 Functors.fmap
+Functors.fmap_with_path
 Functors.@functor
 Functors.@leaf
 ```
@@ -24,6 +25,7 @@ Functors.IterateWalk
 
 ```@docs
 Functors.fmapstructure
+Functors.fmapstructure_with_path
 Functors.fcollect
 ```
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -31,4 +31,5 @@ Functors.fcollect
 
 ```@docs
 Functors.KeyPath
+Functors.getkeypath
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -26,3 +26,7 @@ Functors.IterateWalk
 Functors.fmapstructure
 Functors.fcollect
 ```
+
+```@docs
+Functors.KeyPath
+```

--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -1,7 +1,7 @@
 module Functors
 
 export @functor, @flexiblefunctor, fmap, fmapstructure, fcollect, execute, 
-       KeyPath, fmap_with_keypath
+       KeyPath, fmap_with_path
 
 include("functor.jl")
 include("walks.jl")
@@ -307,7 +307,7 @@ fcollect
 
 
 """"
-    fmap_with_keypath(f, x, ys...; exclude = Functors.isleaf, walk = Functors.DefaultWalkWithKeyPath())
+    fmap_with_path(f, x, ys...; exclude = isleaf, walk = DefaultWalkWithPath())
 
 Like [`fmap`](@ref), but also passes a `KeyPath` to `f` for each node in the
 recursion. The `KeyPath` is a tuple of the indices used to reach the current
@@ -325,10 +325,10 @@ julia> x = ([1, 2, 3], 4, (a=5, b=Dict("A"=>6, "B"=>7), c=Dict("C"=>8, "D"=>9)))
 
 julia> fexclude(kp, x) = kp == KeyPath(3, :c) || Functors.isleaf(x)
 
-julia> fmap_with_keypath((kp, x) -> x isa Dict ? nothing : x.^2, x; exclude = fexclude)
+julia> fmap_with_path((kp, x) -> x isa Dict ? nothing : x.^2, x; exclude = fexclude)
 ([1, 4, 9], 16, (a = 25, b = Dict("B" => 49, "A" => 36), c = nothing))
 ```
 """
-fmap_with_keypath
+fmap_with_path
 
 end # module

--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -1,7 +1,7 @@
 module Functors
 
 export @functor, @flexiblefunctor, fmap, fmapstructure, fcollect, execute, 
-       KeyPath
+       KeyPath, fmap_with_keypath
 
 include("functor.jl")
 include("walks.jl")
@@ -304,5 +304,31 @@ julia> fcollect(m, exclude = v -> Functors.isleaf(v))
 ```
 """
 fcollect
+
+
+""""
+    fmap_with_keypath(f, x, ys...; exclude = Functors.isleaf, walk = Functors.DefaultWalkWithKeyPath())
+
+Like [`fmap`](@ref), but also passes a `KeyPath` to `f` for each node in the
+recursion. The `KeyPath` is a tuple of the indices used to reach the current
+node from the root of the recursion. The `KeyPath` is constructed by the
+`walk` function, and can be used to reconstruct the path to the current node
+from the root of the recursion.
+
+`f` should accept two arguments: the value of the current node, and the associated `KeyPath`.
+`exclude` also receives the `KeyPath` as its first argument.
+
+# Examples
+
+```jldoctest
+julia> x = ([1, 2, 3], 4, (a=5, b=Dict("A"=>6, "B"=>7), c=Dict("C"=>8, "D"=>9)));
+
+julia> fexclude(kp, x) = kp == KeyPath(3, :c) || Functors.isleaf(x)
+
+julia> fmap_with_keypath((kp, x) -> x isa Dict ? nothing : x.^2, x; exclude = fexclude)
+([1, 4, 9], 16, (a = 25, b = Dict("B" => 49, "A" => 36), c = nothing))
+```
+"""
+fmap_with_keypath
 
 end # module

--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -1,7 +1,7 @@
 module Functors
 
 export @functor, @flexiblefunctor, fmap, fmapstructure, fcollect, execute, 
-       KeyPath, fmap_with_path, fmapstructure_with_path
+       KeyPath, getkeypath, fmap_with_path, fmapstructure_with_path
 
 include("functor.jl")
 include("keypath.jl")

--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -1,13 +1,13 @@
 module Functors
 
 export @functor, @flexiblefunctor, fmap, fmapstructure, fcollect, execute, 
-       KeyPath, fmap_with_path
+       KeyPath, fmap_with_path, fmapstructure_with_path
 
 include("functor.jl")
+include("keypath.jl")
 include("walks.jl")
 include("maps.jl")
 include("base.jl")
-include("keypath.jl")
 
 ###
 ### Docstrings for basic functionality
@@ -106,7 +106,7 @@ Equivalent to `functor(x)[1]`.
 children
 
 """
-    fmap(f, x, ys...; exclude = Functors.isleaf, walk = Functors.DefaultWalk()[, prune])
+    fmap(f, x, ys...; exclude = Functors.isleaf, walk = Functors.DefaultWalk(), [prune])
 
 A structure and type preserving `map`.
 
@@ -323,12 +323,21 @@ from the root of the recursion.
 ```jldoctest
 julia> x = ([1, 2, 3], 4, (a=5, b=Dict("A"=>6, "B"=>7), c=Dict("C"=>8, "D"=>9)));
 
-julia> fexclude(kp, x) = kp == KeyPath(3, :c) || Functors.isleaf(x)
+julia> fexclude(kp, x) = kp == KeyPath(3, :c) || Functors.isleaf(x);
 
 julia> fmap_with_path((kp, x) -> x isa Dict ? nothing : x.^2, x; exclude = fexclude)
 ([1, 4, 9], 16, (a = 25, b = Dict("B" => 49, "A" => 36), c = nothing))
 ```
 """
 fmap_with_path
+
+"""
+    fmapstructure_with_path(f, x; exclude = isleaf)
+
+Like [`fmap_with_path`](@ref), but doesn't preserve the type of custom structs.
+Instead, it returns a `NamedTuple`, a `Tuple`, an array, a dict, 
+or a nested set of these.
+"""
+fmapstructure_with_path
 
 end # module

--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -1,11 +1,13 @@
 module Functors
 
-export @functor, @flexiblefunctor, fmap, fmapstructure, fcollect, execute
+export @functor, @flexiblefunctor, fmap, fmapstructure, fcollect, execute, 
+       KeyPath
 
 include("functor.jl")
 include("walks.jl")
 include("maps.jl")
 include("base.jl")
+include("keypath.jl")
 
 ###
 ### Docstrings for basic functionality

--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -115,6 +115,8 @@ by applying `f`, and otherwise traverses `x` recursively using [`functor`](@ref)
 Optionally, it may also be associated with objects `ys` with the same tree structure.
 In that case, `f` is applied to the corresponding leaf nodes in `x` and `ys`.
 
+See also [`fmap_with_path`](@ref) and [`fmapstructure`](@ref).
+
 # Examples
 ```jldoctest
 julia> fmap(string, (x=1, y=(2, 3)))
@@ -224,13 +226,15 @@ fmap
 
 
 """
-    fmapstructure(f, x; exclude = isleaf)
+    fmapstructure(f, x, ys...; [exclude, prune])
 
 Like [`fmap`](@ref), but doesn't preserve the type of custom structs.
 Instead, it returns a `NamedTuple` (or a `Tuple`, or an array),
 or a nested set of these.
 
 Useful for when the output must not contain custom structs.
+
+See also [`fmap`](@ref) and [`fmapstructure_with_path`](@ref).
 
 # Examples
 ```jldoctest
@@ -307,7 +311,7 @@ fcollect
 
 
 """"
-    fmap_with_path(f, x, ys...; exclude = isleaf, walk = DefaultWalkWithPath())
+    fmap_with_path(f, x, ys...; exclude = isleaf, walk = DefaultWalkWithPath(), [prune])
 
 Like [`fmap`](@ref), but also passes a `KeyPath` to `f` for each node in the
 recursion. The `KeyPath` is a tuple of the indices used to reach the current
@@ -315,8 +319,13 @@ node from the root of the recursion. The `KeyPath` is constructed by the
 `walk` function, and can be used to reconstruct the path to the current node
 from the root of the recursion.
 
-`f` should accept two arguments: the value of the current node, and the associated `KeyPath`.
-`exclude` also receives the `KeyPath` as its first argument.
+`f` has to accept two arguments: the value of the current node and the associated `KeyPath`.
+
+`exclude` also receives the `KeyPath` as its first argument and a node as its second.
+It should return `true` if the recursion should not continue on its children and `f` applied to it.
+
+`prune` is used to control the behaviour when the same node appears twice, see [`fmap`](@ref)
+for more information.
 
 # Examples
 
@@ -332,11 +341,13 @@ julia> fmap_with_path((kp, x) -> x isa Dict ? nothing : x.^2, x; exclude = fexcl
 fmap_with_path
 
 """
-    fmapstructure_with_path(f, x; exclude = isleaf)
+    fmapstructure_with_path(f, x, ys...; [exclude, prune])
 
 Like [`fmap_with_path`](@ref), but doesn't preserve the type of custom structs.
-Instead, it returns a `NamedTuple`, a `Tuple`, an array, a dict, 
+Instead, it returns a named tuple, a tuple, an array, a dict, 
 or a nested set of these.
+
+See also [`fmapstructure`](@ref).
 """
 fmapstructure_with_path
 

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -51,7 +51,6 @@ macro functor(args...)
 end
 
 isleaf(@nospecialize(x)) = children(x) === NoChildren()
-isleaf(::KeyPath, @nospecialize(x)) = isleaf(x)
 
 children(x) = functor(x)[1]
 

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -51,6 +51,7 @@ macro functor(args...)
 end
 
 isleaf(@nospecialize(x)) = children(x) === NoChildren()
+isleaf(::KeyPath, @nospecialize(x)) = isleaf(x)
 
 children(x) = functor(x)[1]
 

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -37,6 +37,8 @@ function makefunctor(m::Module, T, fs = fieldnames(T))
       reconstruct(y::NamedTuple) = $T($(escargs_nt...))
       return (;$(escfs...)), reconstruct
     end
+
+    Base.getindex(x::$T, kp::KeyPath) = $getkeypath(x, kp)
   end
 end
 

--- a/src/keypath.jl
+++ b/src/keypath.jl
@@ -22,6 +22,7 @@ struct KeyPath{T<:Tuple}
 end
 
 @functor KeyPath
+isleaf(::KeyPath, @nospecialize(x)) = isleaf(x)
 
 function KeyPath(keys::Union{KeyT, KeyPath}...)
     ks = (k isa KeyPath ? (k.keys...,) : (k,) for k in keys)

--- a/src/keypath.jl
+++ b/src/keypath.jl
@@ -31,7 +31,16 @@ end
 Base.getindex(kp::KeyPath, i::Int) = kp.keys[i]
 Base.length(kp::KeyPath) = length(kp.keys)
 Base.iterate(kp::KeyPath, state=1) = iterate(kp.keys, state)
+Base.:(==)(kp1::KeyPath, kp2::KeyPath) = kp1.keys == kp2.keys
 
-Base.show(io::IO, kp::KeyPath) = print(io, "KeyPath$(kp.keys)")
+function Base.show(io::IO, kp::KeyPath)
+    compat = get(io, :compact, false)
+    if compat
+        print(io, keypathstr(kp))          
+    else
+        print(io, "KeyPath$(kp.keys)")
+    end
+end
 
+keypathstr(kp::KeyPath) = join(kp.keys, ".")
 

--- a/src/keypath.jl
+++ b/src/keypath.jl
@@ -1,4 +1,4 @@
-KeyT = Union{Symbol, String, Int}
+KeyT = Union{Symbol, AbstractString, Integer}
 
 """
     KeyPath(keys...)

--- a/src/keypath.jl
+++ b/src/keypath.jl
@@ -53,6 +53,11 @@ _getkey(x, k::Symbol) = getfield(x, k)
 _getkey(x::AbstractDict, k::Symbol) = x[k]
 _getkey(x, k::AbstractString) = x[k]
 
+"""
+    getkeypath(x, kp::KeyPath)
+
+Return the value in `x` at the path `kp`.
+"""
 function getkeypath(x, kp::KeyPath)
     if isempty(kp)
         return x

--- a/src/keypath.jl
+++ b/src/keypath.jl
@@ -1,3 +1,5 @@
+using Base: tail
+
 KeyT = Union{Symbol, AbstractString, Integer}
 
 """
@@ -33,6 +35,7 @@ Base.getindex(kp::KeyPath, i::Int) = kp.keys[i]
 Base.length(kp::KeyPath) = length(kp.keys)
 Base.iterate(kp::KeyPath, state=1) = iterate(kp.keys, state)
 Base.:(==)(kp1::KeyPath, kp2::KeyPath) = kp1.keys == kp2.keys
+Base.tail(kp::KeyPath) = KeyPath(Base.tail(kp.keys))
 
 function Base.show(io::IO, kp::KeyPath)
     compat = get(io, :compact, false)
@@ -45,3 +48,15 @@ end
 
 keypathstr(kp::KeyPath) = join(kp.keys, ".")
 
+_getkey(x, k::Integer) = x[k]
+_getkey(x, k::Symbol) = getfield(x, k)
+_getkey(x::AbstractDict, k::Symbol) = x[k]
+_getkey(x, k::AbstractString) = x[k]
+
+function getkeypath(x, kp::KeyPath)
+    if isempty(kp)
+        return x
+    else
+        return getkeypath(_getkey(x, first(kp)), tail(kp))
+    end
+end

--- a/src/keypath.jl
+++ b/src/keypath.jl
@@ -1,0 +1,37 @@
+KeyT = Union{Symbol, String, Int}
+
+"""
+    KeyPath(keys...)
+
+A type for representing a path of keys to a value in a nested structure.
+Can be constructed with a sequence of keys, or by concatenating other `KeyPath`s.
+Keys can be of type `Symbol`, `String`, or `Int`.
+
+# Examples
+
+```jldoctest
+julia> kp = KeyPath(:b, 3)
+KeyPath(:b, 3)
+
+julia> KeyPath(:a, kp, :c, 4)
+KeyPath(:a, :b, 3, :c, 4)
+```
+"""
+struct KeyPath{T<:Tuple}
+    keys::T    
+end
+
+@functor KeyPath
+
+function KeyPath(keys::Union{KeyT, KeyPath}...)
+    ks = (k isa KeyPath ? (k.keys...,) : (k,) for k in keys)
+    return KeyPath(((ks...)...,))
+end
+
+Base.getindex(kp::KeyPath, i::Int) = kp.keys[i]
+Base.length(kp::KeyPath) = length(kp.keys)
+Base.iterate(kp::KeyPath, state=1) = iterate(kp.keys, state)
+
+Base.show(io::IO, kp::KeyPath) = print(io, "KeyPath$(kp.keys)")
+
+

--- a/src/maps.jl
+++ b/src/maps.jl
@@ -11,6 +11,32 @@ function fmap(f, x, ys...; exclude = isleaf,
   execute(_walk, x, ys...)
 end
 
+""""
+    fmap_with_keypath(f, x, ys...; exclude = Functors.isleaf, walk = Functors.DefaultWalkWithKeyPath())
+
+Like [`fmap`](@ref), but also passes a `KeyPath` to `f` for each node in the
+recursion. The `KeyPath` is a tuple of the indices used to reach the current
+node from the root of the recursion. The `KeyPath` is constructed by the
+`walk` function, and can be used to reconstruct the path to the current node
+from the root of the recursion.
+
+# Examples
+
+```jldoctest
+julia> fmap_with_keypath((x, kp) -> (x, kp), (1, (2, 3)))
+(1, ())
+(2, (1,))
+(3, (2,))
+```
+"""
+function fmap_with_keypath(f, x, ys...; 
+                exclude = isleaf,
+                walk = DefaultWalkWithKeyPath())
+  
+  _walk = ExcludeWalkWithKeyPath(walk, f, exclude)
+  return execute(_walk, KeyPath(), x, ys...)
+end
+
 fmapstructure(f, x; kwargs...) = fmap(f, x; walk = StructuralWalk(), kwargs...)
 
 fcollect(x; exclude = v -> false) =

--- a/src/maps.jl
+++ b/src/maps.jl
@@ -13,15 +13,20 @@ end
 
 function fmap_with_path(f, x, ys...; 
                 exclude = isleaf,
-                walk = DefaultWalkWithPath())
+                walk = DefaultWalkWithPath(),
+                cache = IdDict(),
+                prune = NoKeyword())
   
   _walk = ExcludeWalkWithKeyPath(walk, f, exclude)
+  if !isnothing(cache)
+    _walk = CachedWalkWithPath(_walk, prune, cache)
+  end
   return execute(_walk, KeyPath(), x, ys...)
 end
 
-fmapstructure(f, x; kwargs...) = fmap(f, x; walk = StructuralWalk(), kwargs...)
+fmapstructure(f, x, ys...; kwargs...) = fmap(f, x, ys...; walk = StructuralWalk(), kwargs...)
 
-fmapstructure_with_path(f, x; kwargs...) = fmap_with_path(f, x; walk = StructuralWalkWithPath(), kwargs...)
+fmapstructure_with_path(f, x, ys...; kwargs...) = fmap_with_path(f, x, ys...; walk = StructuralWalkWithPath(), kwargs...)
 
 fcollect(x; exclude = v -> false) =
   execute(ExcludeWalk(CollectWalk(), _ -> nothing, exclude), x)

--- a/src/maps.jl
+++ b/src/maps.jl
@@ -11,24 +11,6 @@ function fmap(f, x, ys...; exclude = isleaf,
   execute(_walk, x, ys...)
 end
 
-""""
-    fmap_with_path(f, x, ys...; exclude = Functors.isleaf, walk = Functors.DefaultWalkWithPath())
-
-Like [`fmap`](@ref), but also passes a `KeyPath` to `f` for each node in the
-recursion. The `KeyPath` is a tuple of the indices used to reach the current
-node from the root of the recursion. The `KeyPath` is constructed by the
-`walk` function, and can be used to reconstruct the path to the current node
-from the root of the recursion.
-
-# Examples
-
-```jldoctest
-julia> fmap_with_path((x, kp) -> (x, kp), (1, (2, 3)))
-(1, ())
-(2, (1,))
-(3, (2,))
-```
-"""
 function fmap_with_path(f, x, ys...; 
                 exclude = isleaf,
                 walk = DefaultWalkWithPath())
@@ -38,6 +20,8 @@ function fmap_with_path(f, x, ys...;
 end
 
 fmapstructure(f, x; kwargs...) = fmap(f, x; walk = StructuralWalk(), kwargs...)
+
+fmapstructure_with_path(f, x; kwargs...) = fmap_with_path(f, x; walk = StructuralWalkWithPath(), kwargs...)
 
 fcollect(x; exclude = v -> false) =
   execute(ExcludeWalk(CollectWalk(), _ -> nothing, exclude), x)

--- a/src/maps.jl
+++ b/src/maps.jl
@@ -12,7 +12,7 @@ function fmap(f, x, ys...; exclude = isleaf,
 end
 
 """"
-    fmap_with_keypath(f, x, ys...; exclude = Functors.isleaf, walk = Functors.DefaultWalkWithKeyPath())
+    fmap_with_path(f, x, ys...; exclude = Functors.isleaf, walk = Functors.DefaultWalkWithPath())
 
 Like [`fmap`](@ref), but also passes a `KeyPath` to `f` for each node in the
 recursion. The `KeyPath` is a tuple of the indices used to reach the current
@@ -23,15 +23,15 @@ from the root of the recursion.
 # Examples
 
 ```jldoctest
-julia> fmap_with_keypath((x, kp) -> (x, kp), (1, (2, 3)))
+julia> fmap_with_path((x, kp) -> (x, kp), (1, (2, 3)))
 (1, ())
 (2, (1,))
 (3, (2,))
 ```
 """
-function fmap_with_keypath(f, x, ys...; 
+function fmap_with_path(f, x, ys...; 
                 exclude = isleaf,
-                walk = DefaultWalkWithKeyPath())
+                walk = DefaultWalkWithPath())
   
   _walk = ExcludeWalkWithKeyPath(walk, f, exclude)
   return execute(_walk, KeyPath(), x, ys...)

--- a/src/walks.jl
+++ b/src/walks.jl
@@ -81,9 +81,9 @@ function (::DefaultWalk)(recurse, x, ys...)
   re(_map(recurse, func, yfuncs...))
 end
 
-struct DefaultWalkWithKeyPath <: AbstractWalk end
+struct DefaultWalkWithPath <: AbstractWalk end
 
-function (::DefaultWalkWithKeyPath)(recurse, kp::KeyPath, x, ys...)
+function (::DefaultWalkWithPath)(recurse, kp::KeyPath, x, ys...)
   x_children, re = functor(x)
   kps = _map(c -> KeyPath(kp, c), _keys(x_children)) # use _keys and _map to preserve x_children type
   ys_children = map(children, ys)

--- a/src/walks.jl
+++ b/src/walks.jl
@@ -1,4 +1,13 @@
-_map(f, x...) = map(f, x...)
+function _map(f, x, ys...)
+  check_lenghts(x, ys...) || error("all arguments must have at least the same length of the firs one")
+  map(f, x, ys...)
+end
+
+function check_lenghts(x, ys...)
+  n = length(x)
+  return all(y -> length(y) >= n, ys)
+end
+
 _map(f, x::Dict, ys...) = Dict(k => f(v, (y[k] for y in ys)...) for (k, v) in x)
 
 _values(x) = x
@@ -8,6 +17,7 @@ _keys(x::Dict) = Dict(k => k for k in keys(x))
 _keys(x::Tuple) = (keys(x)...,)
 _keys(x::AbstractArray) = collect(keys(x))
 _keys(x::NamedTuple{Ks}) where Ks = NamedTuple{Ks}(Ks)
+
 
 """
     AbstractWalk
@@ -101,7 +111,11 @@ See [`fmapstructure`](@ref) for more information.
 """
 struct StructuralWalk <: AbstractWalk end
 
-(::StructuralWalk)(recurse, x) = _map(recurse, children(x))
+function (::StructuralWalk)(recurse, x, ys...)
+  x_children = children(x)
+  ys_children = map(children, ys)
+  return _map(recurse, x_children, ys_children...)
+end
 
 struct StructuralWalkWithPath <: AbstractWalk end
 

--- a/src/walks.jl
+++ b/src/walks.jl
@@ -6,7 +6,7 @@ _values(x::Dict) = values(x)
 
 _keys(x::Dict) = Dict(k => k for k in keys(x))
 _keys(x::Tuple) = (keys(x)...,)
-_keys(x::AbstractArray) = collect(x)
+_keys(x::AbstractArray) = collect(keys(x))
 _keys(x::NamedTuple{Ks}) where Ks = NamedTuple{Ks}(Ks)
 
 """
@@ -102,6 +102,15 @@ See [`fmapstructure`](@ref) for more information.
 struct StructuralWalk <: AbstractWalk end
 
 (::StructuralWalk)(recurse, x) = _map(recurse, children(x))
+
+struct StructuralWalkWithPath <: AbstractWalk end
+
+function (::StructuralWalkWithPath)(recurse, kp::KeyPath, x, ys...)
+  x_children = children(x)
+  kps = _map(c -> KeyPath(kp, c), _keys(x_children)) # use _keys and _map to preserve x_children type
+  ys_children = map(children, ys)
+  return _map(recurse, kps, x_children, ys_children...)
+end
 
 """
     ExcludeWalk(walk, fn, exclude)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -392,3 +392,12 @@ end
 @testset "Deprecated first-arg walk API to fmap" begin
   @test (@test_deprecated fmap(Functors.DefaultWalk(), nothing, (1, 2, 3))) == (1, 2, 3)
 end
+
+@testset "fmapstructure_with_path" begin
+  m = Bar(Foo(Dict("a" => 1, "b" => (b1=2, b2=20)), [3, 4, (5, 6)]))
+  res = fmapstructure_with_path((kp, x) -> x^2, m)
+  @test res == (x = (x = Dict("b" => (b1=4, b2=400), "a" => 1), y = [9, 16, (25, 36)]),)
+  res = fmapstructure_with_path((kp, x) -> x isa Number ? x^2 : nothing, m, 
+          exclude = (kp, x) -> (kp ∈ (KeyPath(:x, :x, "b"), KeyPath(:x, :y, 3)) || Functors.isleaf(x)))
+  @test res == (x = (x = Dict("b" => nothing, "a" => 1), y = [9, 16, nothing]),)
+end 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -4,8 +4,12 @@ using Functors: functor, usecache
 struct Foo; x; y; end
 @functor Foo
 
+Base.:(==)(x::Foo, y::Foo) = x.x == y.x && x.y == y.y
+
 struct Bar{T}; x::T; end
 @functor Bar
+
+Base.:(==)(x::Bar, y::Bar) = x.x == y.x
 
 struct OneChild3; x; y; z; end
 @functor OneChild3 (y,)
@@ -219,7 +223,6 @@ end
   m2 = (x = [1,2], y = (a = [3,4], b = 5))
   n2 = (x = [6,7], y = 8)
   @test_throws Exception fmap(first∘tuple, m2, n2)  # ERROR: type Int64 has no field a
-  @test_throws Exception fmap(first∘tuple, m2, n2)
 
   # The cache uses IDs from the first argument
   shared = [1,2,3]
@@ -238,9 +241,7 @@ end
   @test z4.x === z4.z
 
   @test fmap(+, foo1, m1, n1) isa Foo
-  @static if VERSION >= v"1.6" # fails on Julia 1.0
-    @test fmap(.*, m1, foo1, n1) == (x = [4*7, 2*5*8], y = 3*6*9)
-  end
+  @test fmap(.*, m1, foo1, n1) == (x = [4*7, 2*5*8], y = 3*6*9)
 end
 
 @testset "old test update.jl" begin
@@ -393,11 +394,144 @@ end
   @test (@test_deprecated fmap(Functors.DefaultWalk(), nothing, (1, 2, 3))) == (1, 2, 3)
 end
 
+
+@testset "fmap_with_path" begin
+  @testset "basic properties" begin
+    m = Bar(Foo(Dict("a" => 1, "b" => (b1=2, b2=20)), [3, 4, (5, 6)]))
+    res = fmap_with_path((kp, x) -> x^2, m)
+    @test res == Bar{Foo}(Foo(Dict("b" => (b1 = 4, b2 = 400), "a" => 1), [9, 16, (25, 36)]))
+    res = fmap_with_path((kp, x) -> x isa Number ? x^2 : nothing, m, 
+            exclude = (kp, x) -> (kp ∈ (KeyPath(:x, :x, "b"), KeyPath(:x, :y, 3)) || Functors.isleaf(x)))
+    @test res == Bar{Foo}(Foo(Dict("b" => nothing, "a" => 1), [9, 16, nothing]))
+  end
+
+  @testset "sharing" begin
+    shared = [1,2,3]
+    m1 = Foo(shared, Foo([1,2,3], Foo(shared, [1,2,3])))
+    m1f = fmap_with_path((kp, x) -> float(x), m1)
+    @test m1f.x === m1f.y.y.x
+    @test m1f.x !== m1f.y.x
+    m1no = fmap_with_path((kp, x) -> float(x), m1; cache = nothing)  # disable the cache by hand
+    @test m1no.x !== m1no.y.y.x
+
+    # Here "4" is not shared, because Foo isn't leaf:
+    m2 = Foo(Foo(shared, 4), Foo(shared, 4))
+    @test m2.x === m2.y
+    m2f = fmap_with_path((kp, x) -> float(x), m2)
+    @test m2f.x.x === m2f.y.x
+   
+   
+    # Shared mutable containers are preserved, even if all children are isbits:
+    ref = Ref(1)
+    m5 = (x = ref, y = ref, z = Ref(1))
+    m5f = fmap_with_path((kp, x) -> x/2, m5)
+    @test m5f.x === m5f.y
+    @test m5f.x !== m5f.z
+  end
+
+  @testset "fmap_with_path(f, x, y)" begin
+    m1 = (x = [1,2], y = 3)
+    n1 = (x = [4,5], y = 6)
+    @test fmap_with_path((kp, x, y) -> x + y, m1, n1) == (x = [5, 7], y = 9)
+
+    # Reconstruction type comes from the first argument
+    foo1 = Foo([7,8], 9)
+    @test fmap_with_path((kp, x, y) -> x + y, m1, foo1) == (x = [8, 10], y = 12)
+    @test fmap_with_path((kp, x, y) -> x + y, foo1, n1) isa Foo
+    @test fmap_with_path((kp, x, y) -> x + y, foo1, n1).x == [11, 13]
+
+    # Mismatched trees should be an error
+    m2 = (x = [1,2], y = (a = [3,4], b = 5))
+    n2 = (x = [6,7], y = 8)
+    @test_broken fmap_with_path((kp, x, y) -> x, m2, n2) isa Exception  # ERROR: type Int64 has no field a
+
+    # The cache uses IDs from the first argument
+    shared = [1,2,3]
+    m3 = (x = shared, y = [4,5,6], z = shared)
+    n3 = (x = shared, y = shared, z = [7,8,9])
+    @test fmap_with_path((kp, x, y) -> x + y, m3, n3) == (x = [2, 4, 6], y = [5, 7, 9], z = [2, 4, 6])
+    z3 = fmap_with_path((kp, x, y) -> x + y, m3, n3)
+    @test z3.x === z3.z
+
+    # Pruning of duplicates:
+    @test fmap_with_path((kp, x, y) -> x + y, m3, n3; prune = nothing) == (x = [2,4,6], y = [5,7,9], z = nothing)
+
+    # More than two arguments:
+    z4 = fmap_with_path((kp, x...) -> +(x...), m3, n3, m3, n3)
+    @test z4 == fmap_with_path((kp, x) -> 2x, z3)
+    @test z4.x === z4.z
+
+    @test fmap_with_path((kp, x...) -> +(x...), foo1, m1, n1) isa Foo
+    @test fmap_with_path((kp, x...) -> .*(x...), m1, foo1, n1) == (x = [4*7, 2*5*8], y = 3*6*9)
+  end
+end
+
 @testset "fmapstructure_with_path" begin
-  m = Bar(Foo(Dict("a" => 1, "b" => (b1=2, b2=20)), [3, 4, (5, 6)]))
-  res = fmapstructure_with_path((kp, x) -> x^2, m)
-  @test res == (x = (x = Dict("b" => (b1=4, b2=400), "a" => 1), y = [9, 16, (25, 36)]),)
-  res = fmapstructure_with_path((kp, x) -> x isa Number ? x^2 : nothing, m, 
-          exclude = (kp, x) -> (kp ∈ (KeyPath(:x, :x, "b"), KeyPath(:x, :y, 3)) || Functors.isleaf(x)))
-  @test res == (x = (x = Dict("b" => nothing, "a" => 1), y = [9, 16, nothing]),)
+  @testset "basic properties" begin
+    m = Bar(Foo(Dict("a" => 1, "b" => (b1=2, b2=20)), [3, 4, (5, 6)]))
+    res = fmapstructure_with_path((kp, x) -> x^2, m)
+    @test res == (x = (x = Dict("b" => (b1=4, b2=400), "a" => 1), y = [9, 16, (25, 36)]),)
+    res = fmapstructure_with_path((kp, x) -> x isa Number ? x^2 : nothing, m, 
+            exclude = (kp, x) -> (kp ∈ (KeyPath(:x, :x, "b"), KeyPath(:x, :y, 3)) || Functors.isleaf(x)))
+    @test res == (x = (x = Dict("b" => nothing, "a" => 1), y = [9, 16, nothing]),)
+  end
+
+  @testset "sharing" begin
+    shared = [1,2,3]
+    m1 = Foo(shared, Foo([1,2,3], Foo(shared, [1,2,3])))
+    m1p = fmapstructure_with_path((kp,x)->x, m1; prune = nothing)
+    @test m1p == (x = [1, 2, 3], y = (x = [1, 2, 3], y = (x = nothing, y = [1, 2, 3])))
+    
+    # Here "4" is not shared, because Foo isn't leaf:
+    m2 = Foo(Foo(shared, 4), Foo(shared, 4))
+    @test m2.x === m2.y
+    m2p = fmapstructure_with_path((kp,x)->x, m2; prune = Bar(0))
+    @test m2p == (x = (x = [1, 2, 3], y = 4), y = (x = Bar{Int64}(0), y = 4))
+
+    # Repeated isbits types should not automatically be regarded as shared:
+    m3 = Foo(Foo(shared, 1:3), Foo(1:3, shared))
+    m3p = fmapstructure_with_path((kp,x)->x, m3; prune = 0)
+    @test m3p.y.y == 0
+    @test m3p.y.x == 1:3
+  end
+
+  
+  # @testset "fmap(f, x, y)" begin
+  #   m1 = (x = [1,2], y = 3)
+  #   n1 = (x = [4,5], y = 6)
+  #   @test fmap(+, m1, n1) == (x = [5, 7], y = 9)
+
+  #   # Reconstruction type comes from the first argument
+  #   foo1 = Foo([7,8], 9)
+  #   @test fmap(+, m1, foo1) == (x = [8, 10], y = 12)
+  #   @test fmap(+, foo1, n1) isa Foo
+  #   @test fmap(+, foo1, n1).x == [11, 13]
+
+  #   # Mismatched trees should be an error
+  #   m2 = (x = [1,2], y = (a = [3,4], b = 5))
+  #   n2 = (x = [6,7], y = 8)
+  #   @test_throws Exception fmap(first∘tuple, m2, n2)  # ERROR: type Int64 has no field a
+  #   @test_throws Exception fmap(first∘tuple, m2, n2)
+
+  #   # The cache uses IDs from the first argument
+  #   shared = [1,2,3]
+  #   m3 = (x = shared, y = [4,5,6], z = shared)
+  #   n3 = (x = shared, y = shared, z = [7,8,9])
+  #   @test fmap(+, m3, n3) == (x = [2, 4, 6], y = [5, 7, 9], z = [2, 4, 6])
+  #   z3 = fmap(+, m3, n3)
+  #   @test z3.x === z3.z
+
+  #   # Pruning of duplicates:
+  #   @test fmap(+, m3, n3; prune = nothing) == (x = [2,4,6], y = [5,7,9], z = nothing)
+
+  #   # More than two arguments:
+  #   z4 = fmap(+, m3, n3, m3, n3)
+  #   @test z4 == fmap(x -> 2x, z3)
+  #   @test z4.x === z4.z
+
+  #   @test fmap(+, foo1, m1, n1) isa Foo
+  #   @static if VERSION >= v"1.6" # fails on Julia 1.0
+  #     @test fmap(.*, m1, foo1, n1) == (x = [4*7, 2*5*8], y = 3*6*9)
+  #   end
+  # end
 end 

--- a/test/keypath.jl
+++ b/test/keypath.jl
@@ -15,4 +15,25 @@
 
     kp0 = KeyPath()
     @test (kp0...,) === ()
+
+    @testset "getkeypath" begin
+        x = Dict(:a => 3, :b => Dict(:c => 4, "d" => [5, 6, 7]))
+        @test getkeypath(x, KeyPath(:a)) == 3
+        @test getkeypath(x, KeyPath(:b, :c)) == 4
+        @test getkeypath(x, KeyPath(:b, "d", 2)) == 6
+   
+        @testset "@functor defines keypath indexing" begin
+            struct Tkp
+                a
+                b
+                c
+            end
+            @functor Tkp
+                
+            x = Tkp(3, Tkp(4, 5, 6), (7, 8))
+            kp = KeyPath(:b, :b, 1)
+            @test x[kp] == getkeypath(x, kp)
+            @test x[KeyPath(:c, :2)] == 8
+        end
+    end
 end

--- a/test/keypath.jl
+++ b/test/keypath.jl
@@ -1,0 +1,18 @@
+@testset "KeyPath" begin
+    kp = KeyPath(:a, 3, :b, 4)
+    @test (kp...,) === (:a, 3, :b, 4)
+    @test length(kp) == 4
+    @test kp[1] == :a
+    @test kp[2] == 3
+    @test kp[3] == :b
+    @test kp[4] == 4
+
+    kp2 = KeyPath(:a, kp, :c, 5)
+    @test (kp2...,) === (:a, :a, 3, :b, 4, :c, 5)
+
+    kp3 = KeyPath(kp, kp2)
+    @test (kp3...,) === (:a, 3, :b, 4, :a, :a, 3, :b, 4, :c, 5)    
+
+    kp0 = KeyPath()
+    @test (kp0...,) === ()
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using StaticArrays
 
   include("basics.jl")
   include("base.jl")
+  include("keypath.jl")
 
   if VERSION < v"1.6" # || VERSION > v"1.7-"
     @warn "skipping doctests, on Julia $VERSION"


### PR DESCRIPTION
Some speculative accessors on top of #74 so that we can have
```julia
x = Dict(:a => 3, :b => Dict(:c => 4, "d" => [5, 6, 7]))
kp = KeyPath(:b, "d", 2)
@assert getkeypath(x, kp) == 6
```
Even more speculative in this PR is that we define indexing with a KeyPath for `@functor`ized types.
