### PR TITLE
add `getkeypath` and `haskeypath`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -48,4 +48,6 @@ Functors.IterateWalk
 
 ```@docs
 Functors.KeyPath
+Functors.haskeypath
+Functors.getkeypath
 ```

--- a/src/Functors.jl
+++ b/src/Functors.jl
@@ -1,7 +1,8 @@
 module Functors
 
-export @functor, @flexiblefunctor, fmap, fmapstructure, fcollect, execute, fleaves, 
-       KeyPath, fmap_with_path, fmapstructure_with_path
+export @functor, @flexiblefunctor, fmap, fmapstructure, fcollect, execute, fleaves,
+       fmap_with_path, fmapstructure_with_path,
+       KeyPath, getkeypath, haskeypath
 
 include("functor.jl")
 include("keypath.jl")

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -37,6 +37,8 @@ function makefunctor(m::Module, T, fs = fieldnames(T))
       reconstruct(y::NamedTuple) = $T($(escargs_nt...))
       return (;$(escfs...)), reconstruct
     end
+
+    Base.getindex(x::$T, kp::KeyPath) = getkeypath(x, kp)
   end
 end
 

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -37,8 +37,6 @@ function makefunctor(m::Module, T, fs = fieldnames(T))
       reconstruct(y::NamedTuple) = $T($(escargs_nt...))
       return (;$(escfs...)), reconstruct
     end
-
-    Base.getindex(x::$T, kp::KeyPath) = getkeypath(x, kp)
   end
 end
 

--- a/src/keypath.jl
+++ b/src/keypath.jl
@@ -67,6 +67,19 @@ _haskey(x, k::AbstractString) = haskey(x, k)
     getkeypath(x, kp::KeyPath)
 
 Return the value in `x` at the path `kp`.
+
+See also [`haskeypath`](@ref).
+
+# Examples
+```jldoctest
+julia> x = Dict(:a => 3, :b => Dict(:c => 4, "d" => [5, 6, 7]))
+Dict{Any,Any} with 2 entries:
+  :a => 3
+  :b => Dict{Any,Any}(:c=>4,"d"=>[5, 6, 7])
+
+julia> getkeypath(x, KeyPath(:b, "d", 2))
+6
+```
 """
 function getkeypath(x, kp::KeyPath)
     if isempty(kp)
@@ -76,6 +89,29 @@ function getkeypath(x, kp::KeyPath)
     end
 end
 
+"""
+    haskeypath(x, kp::KeyPath)
+
+Return `true` if `x` has a value at the path `kp`.
+
+See also [`getkeypath`](@ref).
+
+# Examples
+```jldoctest
+julia> x = Dict(:a => 3, :b => Dict(:c => 4, "d" => [5, 6, 7]))
+Dict{Any,Any} with 2 entries:
+  :a => 3
+  :b => Dict{Any,Any}(:c=>4,"d"=>[5, 6, 7])
+
+julia> haskeypath(x, KeyPath(:a))
+true
+
+julia> haskeypath(x, KeyPath(:b, "d", 1))
+true
+
+julia> haskeypath(x, KeyPath(:b, "d", 4))
+false
+"""
 function haskeypath(x, kp::KeyPath)
     if isempty(kp)
         return true

--- a/src/keypath.jl
+++ b/src/keypath.jl
@@ -68,8 +68,6 @@ _haskey(x, k::AbstractString) = haskey(x, k)
 
 Return the value in `x` at the path `kp`.
 
-For object types on which `@functor` has been applied, `x[kp]` is equivalent to `getkeypath(x, kp)`.
-
 See also [`haskeypath`](@ref).
 
 # Examples

--- a/src/keypath.jl
+++ b/src/keypath.jl
@@ -1,3 +1,5 @@
+using Base: tail
+
 KeyT = Union{Symbol, AbstractString, Integer}
 
 """
@@ -29,10 +31,14 @@ function KeyPath(keys::Union{KeyT, KeyPath}...)
     return KeyPath(((ks...)...,))
 end
 
+Base.isempty(kp::KeyPath) = false
+Base.isempty(kp::KeyPath{Tuple{}}) = true
 Base.getindex(kp::KeyPath, i::Int) = kp.keys[i]
 Base.length(kp::KeyPath) = length(kp.keys)
 Base.iterate(kp::KeyPath, state=1) = iterate(kp.keys, state)
 Base.:(==)(kp1::KeyPath, kp2::KeyPath) = kp1.keys == kp2.keys
+Base.tail(kp::KeyPath) = KeyPath(Base.tail(kp.keys))
+Base.last(kp::KeyPath) = last(kp.keys)
 
 function Base.show(io::IO, kp::KeyPath)
     compat = get(io, :compact, false)
@@ -45,3 +51,36 @@ end
 
 keypathstr(kp::KeyPath) = join(kp.keys, ".")
 
+_getkey(x, k::Integer) = x[k]
+_getkey(x, k::Symbol) = getfield(x, k)
+_getkey(x::AbstractDict, k::Symbol) = x[k]
+_getkey(x, k::AbstractString) = x[k]
+
+_haskey(x, k::Integer) = haskey(x, k)
+_haskey(x::Tuple, k::Integer) = 1 <= k <= length(x)
+_haskey(x::AbstractArray, k::Integer) = 1 <= k <= length(x) # TODO: extend to generic indexing
+_haskey(x, k::Symbol) = k in fieldnames(typeof(x))
+_haskey(x::AbstractDict, k::Symbol) = haskey(x, k)
+_haskey(x, k::AbstractString) = haskey(x, k)
+
+"""
+    getkeypath(x, kp::KeyPath)
+
+Return the value in `x` at the path `kp`.
+"""
+function getkeypath(x, kp::KeyPath)
+    if isempty(kp)
+        return x
+    else
+        return getkeypath(_getkey(x, first(kp)), tail(kp))
+    end
+end
+
+function haskeypath(x, kp::KeyPath)
+    if isempty(kp)
+        return true
+    else
+        k = first(kp)
+        return _haskey(x, k) && haskeypath(_getkey(x, k), tail(kp))
+    end
+end

--- a/src/keypath.jl
+++ b/src/keypath.jl
@@ -68,14 +68,16 @@ _haskey(x, k::AbstractString) = haskey(x, k)
 
 Return the value in `x` at the path `kp`.
 
+For object types on which `@functor` has been applied, `x[kp]` is equivalent to `getkeypath(x, kp)`.
+
 See also [`haskeypath`](@ref).
 
 # Examples
 ```jldoctest
 julia> x = Dict(:a => 3, :b => Dict(:c => 4, "d" => [5, 6, 7]))
-Dict{Any,Any} with 2 entries:
+Dict{Symbol, Any} with 2 entries:
   :a => 3
-  :b => Dict{Any,Any}(:c=>4,"d"=>[5, 6, 7])
+  :b => Dict{Any, Any}(:c=>4, "d"=>[5, 6, 7])
 
 julia> getkeypath(x, KeyPath(:b, "d", 2))
 6

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -400,10 +400,13 @@ end
   @functor A
   a = A(1)
   @test Functors.children(a) === (x = 1,)
-  Functors.@leaf A
-  children, re = Functors.functor(a)
+
+  struct B; x; end
+  Functors.@leaf B
+  b = B(1)
+  children, re = Functors.functor(b)
   @test children == Functors.NoChildren() 
-  @test re(children) === a
+  @test re(children) === b
 end
 
 @testset "IterateWalk" begin

--- a/test/keypath.jl
+++ b/test/keypath.jl
@@ -15,8 +15,6 @@
 
     kp0 = KeyPath()
     @test (kp0...,) === ()
-<<<<<<< HEAD
-=======
 
     @testset "getkeypath" begin
         x = Dict(:a => 3, :b => Dict(:c => 4, "d" => [5, 6, 7]))
@@ -47,5 +45,4 @@
         @test !haskeypath(x, KeyPath(:b, "d", 4))
         @test !haskeypath(x, KeyPath(:b, "e"))
     end
->>>>>>> d6930f1 (getkeypath)
 end

--- a/test/keypath.jl
+++ b/test/keypath.jl
@@ -16,20 +16,40 @@
     kp0 = KeyPath()
     @test (kp0...,) === ()
 
+    struct Tkp
+        a
+        b
+        c
+    end
+
+    function Base.getproperty(x::Tkp, k::Symbol)
+        if k in fieldnames(Tkp)
+            return getfield(x, k)
+        elseif k === :ab
+            return "ab"
+        else        
+            error()
+        end
+    end
+
+    Base.propertynames(::Tkp) = (:a, :b, :c, :ab)
+
     @testset "getkeypath" begin
         x = Dict(:a => 3, :b => Dict(:c => 4, "d" => [5, 6, 7]))
         @test getkeypath(x, KeyPath(:a)) == 3
         @test getkeypath(x, KeyPath(:b, :c)) == 4
         @test getkeypath(x, KeyPath(:b, "d", 2)) == 6
-   
-        struct Tkp
-            a
-            b
-            c
-        end
+
         x = Tkp(3, Tkp(4, 5, (6, 7)), 8)
         kp = KeyPath(:b, :c, 2)
         @test getkeypath(x, kp) == 7
+
+        @testset "access through getproperty" begin
+            x = Tkp(3, Dict(:c => 4, :d => 5), 6);
+
+            @test getkeypath(x, KeyPath(:ab)) == "ab"
+            @test getkeypath(x, KeyPath(:b, :c)) == 4
+        end
     end
 
     @testset "haskeypath" begin
@@ -39,5 +59,13 @@
         @test haskeypath(x, KeyPath(:b, "d", 2))
         @test !haskeypath(x, KeyPath(:b, "d", 4))
         @test !haskeypath(x, KeyPath(:b, "e"))
+
+        @testset "access through getproperty" begin
+            x = Tkp(3, Dict(:c => 4, :d => 5), 6);
+
+            @test haskeypath(x, KeyPath(:ab))
+            @test haskeypath(x, KeyPath(:b, :c))
+            @test !haskeypath(x, KeyPath(:b, :e))
+        end
     end
 end

--- a/test/keypath.jl
+++ b/test/keypath.jl
@@ -22,19 +22,14 @@
         @test getkeypath(x, KeyPath(:b, :c)) == 4
         @test getkeypath(x, KeyPath(:b, "d", 2)) == 6
    
-        @testset "@functor defines keypath indexing" begin
-            struct Tkp
-                a
-                b
-                c
-            end
-            @functor Tkp
-                
-            x = Tkp(3, Tkp(4, 5, 6), (7, 8))
-            kp = KeyPath(:b, :b, 1)
-            @test x[kp] == getkeypath(x, kp)
-            @test x[KeyPath(:c, :2)] == 8
+        struct Tkp
+            a
+            b
+            c
         end
+        x = Tkp(3, Tkp(4, 5, (6, 7)), 8)
+        kp = KeyPath(:b, :c, 2)
+        @test getkeypath(x, kp) == 7
     end
 
     @testset "haskeypath" begin

--- a/test/keypath.jl
+++ b/test/keypath.jl
@@ -15,4 +15,37 @@
 
     kp0 = KeyPath()
     @test (kp0...,) === ()
+<<<<<<< HEAD
+=======
+
+    @testset "getkeypath" begin
+        x = Dict(:a => 3, :b => Dict(:c => 4, "d" => [5, 6, 7]))
+        @test getkeypath(x, KeyPath(:a)) == 3
+        @test getkeypath(x, KeyPath(:b, :c)) == 4
+        @test getkeypath(x, KeyPath(:b, "d", 2)) == 6
+   
+        @testset "@functor defines keypath indexing" begin
+            struct Tkp
+                a
+                b
+                c
+            end
+            @functor Tkp
+                
+            x = Tkp(3, Tkp(4, 5, 6), (7, 8))
+            kp = KeyPath(:b, :b, 1)
+            @test x[kp] == getkeypath(x, kp)
+            @test x[KeyPath(:c, :2)] == 8
+        end
+    end
+
+    @testset "haskeypath" begin
+        x = Dict(:a => 3, :b => Dict(:c => 4, "d" => [5, 6, 7]))
+        @test haskeypath(x, KeyPath(:a))
+        @test haskeypath(x, KeyPath(:b, :c))
+        @test haskeypath(x, KeyPath(:b, "d", 2))
+        @test !haskeypath(x, KeyPath(:b, "d", 4))
+        @test !haskeypath(x, KeyPath(:b, "e"))
+    end
+>>>>>>> d6930f1 (getkeypath)
 end


### PR DESCRIPTION
Some convenience functions for KeyPath on top of #74 so that we can have
```julia
x = Dict(:a => 3, :b => Dict(:c => 4, "d" => [5, 6, 7]))
kp = KeyPath(:b, "d", 2)
@assert haskeypath(x, kp)
@assert getkeypath(x, kp) == 6
```
The possibly controversial part of this PR is that we define indexing with a KeyPath for `@functor`ized types.
This would be no longer possible if we decide to functorize everything by default as proposed in #49, so maybe better leave the indexing part out?

TODO
- [x] wait for #74 to be merged
- [x] ~add a convenience macro constructor kp":a.1.'a'"?~ (not worth it at the moment)
