### PR TITLE
fix: reducing over empty collection

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Functors"
 uuid = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
 authors = ["Mike J Innes <mike.j.innes@gmail.com>"]
-version = "0.4.11"
+version = "0.4.12"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/walks.jl
+++ b/src/walks.jl
@@ -315,6 +315,6 @@ function (walk::FlattenWalk)(recurse, x, ys...)
   x_children = _values(children(x))
   ys_children = map(children, ys)
   res = _map(recurse, x_children, ys_children...)
-  return reduce(vcat, _values(res))
+  return reduce(vcat, _values(res); init = [])
 end
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -439,6 +439,9 @@ end
   @test xflat isa Vector
   @test length(xflat) == 3
   @test 1 ∈ xflat && 2 ∈ xflat && [1, 2, 3] ∈ xflat
+
+  @test fleaves((;)) == []
+  @test fleaves((; a = 1, b = 2, c = (;))) == [1, 2]
 end
 
 @testset "fmap_with_path" begin


### PR DESCRIPTION
### Before the patch

```julia
julia> Functors.fleaves((; a = (;), b=[1, 2]))
ERROR: ArgumentError: reducing over an empty collection is not allowed; consider supplying `init` to the reducer
Stacktrace:
      ⋮ internal @ Base, Unknown
  [9] reduce(op::Function, itr::@NamedTuple{}; kw::@Kwargs{})
    @ Base ./reduce.jl:487
 [10] (::Functors.FlattenWalk)(::Function, ::@NamedTuple{})
    @ Functors /mnt/research/lux/Functors.jl/src/walks.jl:318
 [11] (::Functors.ExcludeWalk{Functors.FlattenWalk, Functors.var"#52#53", typeof(Functors.isleaf)})(::Function, ::@NamedTuple{})
    @ Functors /mnt/research/lux/Functors.jl/src/walks.jl:144
 [12] (::Functors.var"#recurse#26"{Functors.ExcludeWalk{Functors.FlattenWalk, Functors.var"#52#53", typeof(Functors.isleaf)}})(xs::@NamedTuple{})
    @ Functors /mnt/research/lux/Functors.jl/src/walks.jl:52
      ⋮ internal @ Unknown
 [14] map(::Function, ::@NamedTuple{a::@NamedTuple{}, b::Vector{Int64}})
    @ Base ./namedtuple.jl:266
 [15] _map
    @ /mnt/research/lux/Functors.jl/src/walks.jl:3 [inlined]
 [16] (::Functors.FlattenWalk)(::Function, ::@NamedTuple{a::@NamedTuple{}, b::Vector{Int64}})
    @ Functors /mnt/research/lux/Functors.jl/src/walks.jl:317
 [17] (::Functors.ExcludeWalk{Functors.FlattenWalk, Functors.var"#52#53", typeof(Functors.isleaf)})(::Function, ::@NamedTuple{a::@NamedTuple{}, b::Vector{Int64}})
    @ Functors /mnt/research/lux/Functors.jl/src/walks.jl:144
 [18] execute(::Functors.ExcludeWalk{Functors.FlattenWalk, Functors.var"#52#53", typeof(Functors.isleaf)}, ::@NamedTuple{a::@NamedTuple{}, b::Vector{Int64}})
    @ Functors /mnt/research/lux/Functors.jl/src/walks.jl:53
 [19] fleaves(x::@NamedTuple{a::@NamedTuple{}, b::Vector{Int64}}; exclude::Function)
    @ Functors /mnt/research/lux/Functors.jl/src/maps.jl:33
 [20] top-level scope
    @ REPL[4]:1
 [21] top-level scope
    @ none:1
Use `err` to retrieve the full stack trace.
```

### PR Checklist

- [x] Tests are added
- [x] Documentation, if applicable
