### PR TITLE
Extend `KeyPath` to allow `CartesianIndex` keys

### DIFF
--- a/src/keypath.jl
+++ b/src/keypath.jl
@@ -1,18 +1,18 @@
 using Base: tail
 
-KeyT = Union{Symbol, AbstractString, Integer}
+KeyT = Union{Symbol, AbstractString, Integer, CartesianIndex}
 
 """
     KeyPath(keys...)
 
 A type for representing a path of keys to a value in a nested structure.
 Can be constructed with a sequence of keys, or by concatenating other `KeyPath`s.
-Keys can be of type `Symbol`, `String`, or `Int`.
+Keys can be of type `Symbol`, `String`, `Int`, or `CartesianIndex`.
 
 For custom types, access through symbol keys is assumed to be done with `getproperty`.
 For consistency, the method `Base.propertynames` is used to get the viable property names.
 
-For string and integer keys instead, the access is done with `getindex`.
+For string, integer, and cartesian index keys, the access is done with `getindex` instead.
 
 See also [`getkeypath`](@ref), [`haskeypath`](@ref).
 
@@ -85,11 +85,13 @@ end
 keypathstr(kp::KeyPath) = join(kp.keys, ".")
 
 _getkey(x, k::Integer) = x[k]
+_getkey(x::AbstractArray, k::CartesianIndex) = x[k]
 _getkey(x, k::Symbol) = getproperty(x, k)
 _getkey(x::AbstractDict, k::Symbol) = x[k]
 _getkey(x, k::AbstractString) = x[k]
 
 _setkey!(x, k::Integer, v) = (x[k] = v)
+_setkey!(x::AbstractArray, k::CartesianIndex, v) = (x[k] = v)
 _setkey!(x, k::Symbol, v) = setproperty!(x, k, v)
 _setkey!(x::AbstractDict, k::Symbol, v) = (x[k] = v)
 _setkey!(x, k::AbstractString, v) = (x[k] = v)
@@ -97,6 +99,7 @@ _setkey!(x, k::AbstractString, v) = (x[k] = v)
 _haskey(x, k::Integer) = haskey(x, k)
 _haskey(x::Tuple, k::Integer) = 1 <= k <= length(x)
 _haskey(x::AbstractArray, k::Integer) = 1 <= k <= length(x) # TODO: extend to generic indexing
+_haskey(x::AbstractArray, k::CartesianIndex) = checkbounds(Bool, x, k)
 _haskey(x, k::Symbol) = k in propertynames(x)
 _haskey(x::AbstractDict, k::Symbol) = haskey(x, k)
 _haskey(x, k::AbstractString) = haskey(x, k)

--- a/test/keypath.jl
+++ b/test/keypath.jl
@@ -44,6 +44,10 @@
         kp = KeyPath(:b, :c, 2)
         @test getkeypath(x, kp) == 7
 
+        x = [(a=1,) (b=2,)]
+        @test getkeypath(x, KeyPath(CartesianIndex(1, 1), :a)) == 1
+        @test getkeypath(x, KeyPath(CartesianIndex(1, 2), :b)) == 2
+
         @testset "access through getproperty" begin
             x = Tkp(3, Dict(:c => 4, :d => 5), 6);
 
@@ -65,6 +69,10 @@
         kp = KeyPath(:b, :c, 2)
         setkeypath!(x, kp, 17)
         @test x.b.c[2] == 17
+
+        x = [(a=1,) (b=2,)]
+        setkeypath!(x, KeyPath(CartesianIndex(1, 2)), (c=3,))
+        @test x[2] == (c=3,)
     end
 
     @testset "haskeypath" begin
@@ -74,6 +82,11 @@
         @test haskeypath(x, KeyPath(:b, "d", 2))
         @test !haskeypath(x, KeyPath(:b, "d", 4))
         @test !haskeypath(x, KeyPath(:b, "e"))
+
+        x = [(a=1,) (b=2,)]
+        @test haskeypath(x, KeyPath(CartesianIndex(1, 1)))
+        @test haskeypath(x, KeyPath(CartesianIndex(1, 2)))
+        @test !haskeypath(x, KeyPath(CartesianIndex(1, 3)))
 
         @testset "access through getproperty" begin
             x = Tkp(3, Dict(:c => 4, :d => 5), 6);


### PR DESCRIPTION
I ran into this issue while trying to use `fmap_with_path` while implementing an optimizer whose state is represented as a `Matrix{NamedTuple}`:

```
julia> fmap_with_path((k, x) -> (@show(k); x), [(a=1,) (b=2,)]);
ERROR: MethodError: no method matching KeyPath(::KeyPath{Tuple{}}, ::CartesianIndex{2})
The type `KeyPath` exists, but no method is defined for this combination of argument types when trying to construct it.

Closest candidates are:
  KeyPath(::Union{AbstractString, Integer, Symbol, KeyPath}...)
   @ Functors ~/.julia/dev/Functors/src/keypath.jl:60
  KeyPath(::T) where T<:Tuple
   @ Functors ~/.julia/dev/Functors/src/keypath.jl:55

Stacktrace:
  [1] (::Functors.var"#30#31"{KeyPath{Tuple{}}})(c::CartesianIndex{2})
    @ Functors ~/.julia/dev/Functors/src/walks.jl:80
  [2] iterate
    @ ./generator.jl:48 [inlined]
  [3] _collect
    @ ./array.jl:800 [inlined]
  [4] collect_similar
    @ ./array.jl:709 [inlined]
  [5] map
    @ ./abstractarray.jl:3371 [inlined]
  [6] _map
    @ ~/.julia/dev/Functors/src/walks.jl:3 [inlined]
  [7] DefaultWalkWithPath
    @ ~/.julia/dev/Functors/src/walks.jl:80 [inlined]
  [8] ExcludeWalkWithKeyPath
    @ ~/.julia/dev/Functors/src/walks.jl:135 [inlined]
  [9] (::Functors.CachedWalkWithPath{Functors.ExcludeWalkWithKeyPath{…}, Functors.NoKeyword, Functors.WalkCache{…}})(::Function, ::KeyPath{Tuple{}}, ::Matrix{NamedTuple{…} where names})
    @ Functors ~/.julia/dev/Functors/src/walks.jl:199
 [10] execute(walk::Functors.CachedWalkWithPath{Functors.ExcludeWalkWithKeyPath{…}, Functors.NoKeyword, Functors.WalkCache{…}}, x::KeyPath{Tuple{}}, ys::Matrix{NamedTuple{…} where names})
    @ Functors ~/.julia/dev/Functors/src/walks.jl:55
 [11] fmap_with_path(::Function, ::Matrix{NamedTuple{names, Tuple{Int64}} where names}; exclude::Function, walk::Functors.DefaultWalkWithPath, cache::IdDict{Any, Any}, prune::Functors.NoKeyword)
    @ Functors ~/.julia/dev/Functors/src/maps.jl:23
 [12] fmap_with_path(::Function, ::Matrix{NamedTuple{names, Tuple{Int64}} where names})
    @ Functors ~/.julia/dev/Functors/src/maps.jl:14
 [13] top-level scope
    @ REPL[2]:1
Some type information was truncated. Use `show(err)` to see complete types.
```

I can of course change the state representation, but I think this is a rather harmless extension to `KeyPath`. After this patch:

```julia
julia> fmap_with_path((k, x) -> (@show(k); x), [(a=1,) (b=2,)]);
k = KeyPath(CartesianIndex(1, 1), :a)
k = KeyPath(CartesianIndex(1, 2), :b)
```

Version info:

```julia
(jl_i3jhdk) pkg> st
Status `/tmp/jl_i3jhdk/Project.toml`
  [d9f16b24] Functors v0.5.1
```

```julia
julia> versioninfo()
Julia Version 1.11.1
Commit 8f5b7ca12ad (2024-10-16 10:53 UTC)
Build Info:
  Official https://julialang.org/ release
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: 32 × AMD Ryzen 9 3950X 16-Core Processor
  WORD_SIZE: 64
  LLVM: libLLVM-16.0.6 (ORCJIT, znver2)
Threads: 32 default, 0 interactive, 16 GC (on 32 virtual cores)
```